### PR TITLE
支持开发环境跨域代理并修复设置弹窗误关闭

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+dev-proxy.config.json

--- a/README.md
+++ b/README.md
@@ -143,8 +143,23 @@ docker compose up -d
    ```
    随后浏览器访问 `http://localhost:5173`。
 
-3. **开发环境跨域代理（可选）**
-   如果你的图片接口节点没有放开浏览器跨域，先复制示例配置：
+3. **本地开发跨域代理（可选）**
+   如果你的图片接口没有放开浏览器跨域，前端直接请求接口时可能会被浏览器的 CORS 策略拦截。这个可选代理用于本地开发调试：浏览器先请求同源的 Vite 开发服务器，再由 Vite 开发服务器转发到真实接口。
+
+   请求链路如下：
+
+   ```text
+   浏览器页面 http://localhost:5173
+     -> 同源请求 http://localhost:5173/api-proxy/v1/images/generations
+     -> Vite 开发服务器代理转发
+     -> 真实接口 http://127.0.0.1:3000/v1/images/generations
+   ```
+
+   这样浏览器看到的是同源请求，实际跨域请求发生在 Vite 开发服务器这一侧，从而绕开浏览器 CORS 限制。
+
+   注意：这个代理只在 `npm run dev` 启动的 Vite 开发服务器中生效。它不会打包进静态产物，也不会在 Vercel、GitHub Pages 或普通 Nginx 静态部署中生效。
+
+   先复制示例配置：
    ```bash
    cp dev-proxy.config.example.json dev-proxy.config.json
    ```
@@ -158,7 +173,17 @@ docker compose up -d
      "secure": false
    }
    ```
-   然后在页面设置中的 `API URL` 填入与 `target` 相同的地址。开发服务器会把请求改写为同源代理路径，例如 `/api-proxy/v1/images/generations`，从而绕开浏览器 CORS 限制。
+   配置含义：
+
+   - `enabled`：是否启用本地开发代理。
+   - `prefix`：前端同源请求使用的代理路径前缀。
+   - `target`：真实图片接口地址，也就是 Vite 开发服务器要转发到的后端。
+   - `changeOrigin`：转发时是否把请求头中的 `Host` 改成 `target` 的主机名，通常建议保持 `true`。
+   - `secure`：当 `target` 是 HTTPS 时是否校验证书；本地自签名证书可设为 `false`。
+
+   修改配置后需要重新启动开发服务器，并在页面设置中的 `API URL` 填入与 `target` 相同的地址。当前端发现 `API URL` 与 `target` 匹配时，会把请求改写为 `prefix` 开头的同源地址，例如 `/api-proxy/v1/images/generations`。
+
+   如果需要在线上部署中使用代理，请使用 Vercel Function、Cloudflare Worker、Nginx 反向代理或自建后端等服务端方案。
 
 4. **构建静态产物**
    ```bash

--- a/README.md
+++ b/README.md
@@ -117,7 +117,24 @@ services:
    ```
    随后浏览器访问 `http://localhost:5173`。
 
-3. **构建静态产物**
+3. **开发环境跨域代理（可选）**
+   如果你的图片接口节点没有放开浏览器跨域，先复制示例配置：
+   ```bash
+   cp dev-proxy.config.example.json dev-proxy.config.json
+   ```
+   然后修改项目根目录下的本地 `dev-proxy.config.json`：
+   ```json
+   {
+     "enabled": true,
+     "prefix": "/api-proxy",
+     "target": "http://127.0.0.1:3000",
+     "changeOrigin": true,
+     "secure": false
+   }
+   ```
+   然后在页面设置中的 `API URL` 填入与 `target` 相同的地址。开发服务器会把请求改写为同源代理路径，例如 `/api-proxy/v1/images/generations`，从而绕开浏览器 CORS 限制。
+
+4. **构建静态产物**
    ```bash
    npm run build
    ```

--- a/dev-proxy.config.example.json
+++ b/dev-proxy.config.example.json
@@ -1,0 +1,7 @@
+{
+  "enabled": true,
+  "prefix": "/api-proxy",
+  "target": "http://127.0.0.1:3000",
+  "changeOrigin": true,
+  "secure": false
+}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -65,14 +65,13 @@ export default function SettingsModal() {
   }
 
   return (
-    <div
-      className="fixed inset-0 z-[70] flex items-center justify-center p-4"
-      onClick={handleClose}
-    >
-      <div className="absolute inset-0 bg-black/30 backdrop-blur-sm animate-overlay-in" />
+    <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/30 backdrop-blur-sm animate-overlay-in"
+        onClick={handleClose}
+      />
       <div
         className="relative z-10 w-full max-w-md rounded-3xl border border-white/50 bg-white/95 p-5 shadow-2xl ring-1 ring-black/5 animate-modal-in dark:border-white/[0.08] dark:bg-gray-900/95 dark:ring-white/10 overflow-y-auto max-h-[85vh] custom-scrollbar"
-        onClick={(e) => e.stopPropagation()}
       >
         <div className="mb-5 flex items-center justify-between gap-4">
           <h3 className="text-base font-semibold text-gray-800 dark:text-gray-100 flex items-center gap-2">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { AppSettings, ImageApiResponse, TaskParams } from '../types'
+import { buildApiUrl, readClientDevProxyConfig } from './devProxy'
 
 const MIME_MAP: Record<string, string> = {
   png: 'image/png',
@@ -6,27 +7,7 @@ const MIME_MAP: Record<string, string> = {
   webp: 'image/webp',
 }
 
-export function normalizeBaseUrl(baseUrl: string): string {
-  const trimmed = baseUrl.trim()
-  if (!trimmed) return ''
-
-  const input = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed)
-    ? trimmed
-    : `https://${trimmed}`
-
-  try {
-    const url = new URL(input)
-    return `${url.protocol}//${url.host}`
-  } catch {
-    return trimmed.replace(/\/+$/, '')
-  }
-}
-
-function buildUrl(baseUrl: string, path: string): string {
-  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
-  const apiPath = ['v1', path.replace(/^\/+/, '')].join('/')
-  return normalizedBaseUrl ? `${normalizedBaseUrl}/${apiPath}` : `/${apiPath}`
-}
+export { normalizeBaseUrl } from './devProxy'
 
 function isHttpUrl(value: unknown): value is string {
   return typeof value === 'string' && /^https?:\/\//i.test(value)
@@ -78,6 +59,7 @@ export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult>
   const { settings, prompt, params, inputImageDataUrls } = opts
   const isEdit = inputImageDataUrls.length > 0
   const mime = MIME_MAP[params.output_format] || 'image/png'
+  const proxyConfig = readClientDevProxyConfig()
   const requestHeaders = {
     Authorization: `Bearer ${settings.apiKey}`,
     'Cache-Control': 'no-store, no-cache, max-age=0',
@@ -111,7 +93,7 @@ export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult>
         formData.append('image[]', blob, `input-${i + 1}.${ext}`)
       }
 
-      response = await fetch(buildUrl(settings.baseUrl, 'images/edits'), {
+      response = await fetch(buildApiUrl(settings.baseUrl, 'images/edits', proxyConfig), {
         method: 'POST',
         headers: requestHeaders,
         cache: 'no-store',
@@ -135,7 +117,7 @@ export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult>
         body.n = params.n
       }
 
-      response = await fetch(buildUrl(settings.baseUrl, 'images/generations'), {
+      response = await fetch(buildApiUrl(settings.baseUrl, 'images/generations', proxyConfig), {
         method: 'POST',
         headers: {
           ...requestHeaders,

--- a/src/lib/devProxy.ts
+++ b/src/lib/devProxy.ts
@@ -1,0 +1,70 @@
+export interface DevProxyConfig {
+  enabled: boolean
+  prefix: string
+  target: string
+  changeOrigin: boolean
+  secure: boolean
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  const trimmed = baseUrl.trim()
+  if (!trimmed) return ''
+
+  const input = /^[a-zA-Z][a-zA-Z\d+.-]*:\/\//.test(trimmed)
+    ? trimmed
+    : `https://${trimmed}`
+
+  try {
+    const url = new URL(input)
+    return `${url.protocol}//${url.host}`
+  } catch {
+    return trimmed.replace(/\/+$/, '')
+  }
+}
+
+export function normalizeDevProxyConfig(input: unknown): DevProxyConfig | null {
+  if (!input || typeof input !== 'object') return null
+
+  const record = input as Record<string, unknown>
+  const target = normalizeBaseUrl(typeof record.target === 'string' ? record.target : '')
+  if (!target) return null
+
+  const rawPrefix = typeof record.prefix === 'string' ? record.prefix : '/api-proxy'
+  const trimmedPrefix = rawPrefix.trim().replace(/^\/+/, '').replace(/\/+$/, '')
+  const prefix = trimmedPrefix ? `/${trimmedPrefix}` : '/api-proxy'
+
+  return {
+    enabled: Boolean(record.enabled),
+    prefix,
+    target,
+    changeOrigin: record.changeOrigin !== false,
+    secure: Boolean(record.secure),
+  }
+}
+
+export function buildApiUrl(baseUrl: string, path: string, proxyConfig?: DevProxyConfig | null): string {
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  const apiPath = ['v1', path.replace(/^\/+/, '')].join('/')
+  const useProxy =
+    Boolean(proxyConfig?.enabled) &&
+    Boolean(proxyConfig?.target) &&
+    normalizedBaseUrl === proxyConfig?.target
+
+  if (useProxy) {
+    return `${proxyConfig!.prefix}/${apiPath}`
+  }
+
+  return normalizedBaseUrl ? `${normalizedBaseUrl}/${apiPath}` : `/${apiPath}`
+}
+
+export function resolveDevProxyConfig(input: unknown, isDev: boolean): DevProxyConfig | null {
+  if (!isDev) return null
+  return normalizeDevProxyConfig(input)
+}
+
+export function readClientDevProxyConfig(): DevProxyConfig | null {
+  return resolveDevProxyConfig(
+    typeof __DEV_PROXY_CONFIG__ === 'undefined' ? null : __DEV_PROXY_CONFIG__,
+    import.meta.env.DEV,
+  )
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="vite/client" />
 
 declare const __APP_VERSION__: string
+declare const __DEV_PROXY_CONFIG__: unknown
 
 interface ImportMetaEnv {
   readonly VITE_DEFAULT_API_URL?: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,6 @@ import { readFileSync } from 'fs'
 import { normalizeDevProxyConfig } from './src/lib/devProxy'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
-const devProxyConfig = loadDevProxyConfig()
 
 function loadDevProxyConfig() {
   try {
@@ -18,29 +17,33 @@ function loadDevProxyConfig() {
   }
 }
 
-export default defineConfig(({ command }) => ({
-  plugins: [react()],
-  base: './',
-  define: {
-    __APP_VERSION__: JSON.stringify(pkg.version),
-    __DEV_PROXY_CONFIG__: JSON.stringify(command === 'serve' ? devProxyConfig : null),
-  },
-  server: {
-    host: true,
-    proxy:
-      devProxyConfig?.enabled
-        ? {
-            [devProxyConfig.prefix]: {
-              target: devProxyConfig.target,
-              changeOrigin: devProxyConfig.changeOrigin,
-              secure: devProxyConfig.secure,
-              rewrite: (path) =>
-                path.replace(
-                  new RegExp(`^${devProxyConfig.prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
-                  '',
-                ),
-            },
-          }
-        : undefined,
-  },
-}))
+export default defineConfig(({ command }) => {
+  const devProxyConfig = command === 'serve' ? loadDevProxyConfig() : null
+
+  return {
+    plugins: [react()],
+    base: './',
+    define: {
+      __APP_VERSION__: JSON.stringify(pkg.version),
+      __DEV_PROXY_CONFIG__: JSON.stringify(devProxyConfig),
+    },
+    server: {
+      host: true,
+      proxy:
+        devProxyConfig?.enabled
+          ? {
+              [devProxyConfig.prefix]: {
+                target: devProxyConfig.target,
+                changeOrigin: devProxyConfig.changeOrigin,
+                secure: devProxyConfig.secure,
+                rewrite: (path) =>
+                  path.replace(
+                    new RegExp(`^${devProxyConfig.prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+                    '',
+                  ),
+              },
+            }
+          : undefined,
+    },
+  }
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,16 +1,46 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import { readFileSync } from 'fs'
+import { normalizeDevProxyConfig } from './src/lib/devProxy'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
+const devProxyConfig = loadDevProxyConfig()
 
-export default defineConfig({
+function loadDevProxyConfig() {
+  try {
+    return normalizeDevProxyConfig(
+      JSON.parse(readFileSync('./dev-proxy.config.json', 'utf-8')) as unknown,
+    )
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException
+    if (err.code === 'ENOENT') return null
+    throw error
+  }
+}
+
+export default defineConfig(({ command }) => ({
   plugins: [react()],
   base: './',
   define: {
     __APP_VERSION__: JSON.stringify(pkg.version),
+    __DEV_PROXY_CONFIG__: JSON.stringify(command === 'serve' ? devProxyConfig : null),
   },
   server: {
     host: true,
+    proxy:
+      devProxyConfig?.enabled
+        ? {
+            [devProxyConfig.prefix]: {
+              target: devProxyConfig.target,
+              changeOrigin: devProxyConfig.changeOrigin,
+              secure: devProxyConfig.secure,
+              rewrite: (path) =>
+                path.replace(
+                  new RegExp(`^${devProxyConfig.prefix.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`),
+                  '',
+                ),
+            },
+          }
+        : undefined,
   },
-})
+}))


### PR DESCRIPTION
## 变更说明
- 支持通过本地配置文件开启开发环境跨域代理，避免浏览器直接请求图片接口时触发 CORS 预检失败
- 仓库仅提交 `dev-proxy.config.example.json`，本地真实 `dev-proxy.config.json` 已加入忽略，避免把个人节点配置提交到仓库
- 更新 README，补充开发环境代理配置方式
- 修复设置弹窗中文本选中后鼠标滑出弹窗时误触发关闭并保存的问题

## 细节
- `vite.config.ts` 在开发模式下读取 `dev-proxy.config.json` 并注册 Vite `server.proxy`
- 前端请求层会在命中代理配置时改走同源代理前缀
- 设置弹窗关闭逻辑改为仅响应遮罩层点击，不再绑定在最外层容器上

## 验证
- `npm run build`
- 手动验证开发环境代理配置可用
- 手动验证设置弹窗选中文本后拖出弹窗不会误关闭
