### PR TITLE
Add Responses API image generation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GPT Image Playground
 
-基于 OpenAI `gpt-image-2` 接口的图片生成与编辑工具。提供简洁的 Web UI，支持文本生成图片、参考图编辑、可视化参数调节、历史记录管理与本地数据导入导出。
+基于 OpenAI 图像生成接口的图片生成与编辑工具。提供简洁的 Web UI，支持文本生成图片、参考图编辑、可视化参数调节、历史记录管理与本地数据导入导出。
 
 
 > 如有调用非本地的 HTTP API 的需求，请使用 GitHub Pages 版本或自行部署，因为 `.dev` 域名要求页面本身及其加载的资源（的来源）均为 HTTPS。
@@ -39,8 +39,9 @@ https://cooksleep.github.io/gpt_image_playground
 ## ✨ 功能特性
 
 ### 🎨 核心能力
-- **文本生图**：输入提示词，调用 `images/generations` 接口生成图片。
-- **参考图编辑**：支持上传最多 16 张参考图，调用 `images/edits` 接口进行图片编辑。支持文件选择、粘贴和拖拽三种方式。
+- **文本生图**：输入提示词，可调用 `images/generations` 或 Responses API 的 `image_generation` 工具生成图片。
+- **参考图编辑**：支持上传最多 16 张参考图，可调用 `images/edits` 或 Responses API 多模态输入进行图片编辑。支持文件选择、粘贴和拖拽三种方式。
+- **接口模式切换**：支持在设置中选择 Images API (`/v1/images`) 或 Responses API (`/v1/responses`)。
 - **批量生成**：单次可设置生成多张图片。
 
 ### ⚙️ 精细化参数控制
@@ -162,6 +163,8 @@ docker compose up -d
      -> 真实接口 http://127.0.0.1:3000/v1/images/generations
    ```
 
+   选择 Responses API 模式时，同一代理配置会将请求改写为 `/api-proxy/v1/responses`。
+
    这样浏览器看到的是同源请求，实际跨域请求发生在 Vite 开发服务器这一侧，从而绕开浏览器 CORS 限制。
 
    注意：这个代理只在 `npm run dev` 启动的 Vite 开发服务器中生效。它不会打包进静态产物，也不会在 Vercel、GitHub Pages 或普通 Nginx 静态部署中生效。
@@ -188,7 +191,7 @@ docker compose up -d
    - `changeOrigin`：转发时是否把请求头中的 `Host` 改成 `target` 的主机名，通常建议保持 `true`。
    - `secure`：当 `target` 是 HTTPS 时是否校验证书；本地自签名证书可设为 `false`。
 
-   修改配置后需要重新启动开发服务器，并在页面设置中的 `API URL` 填入与 `target` 相同的地址。当前端发现 `API URL` 与 `target` 匹配时，会把请求改写为 `prefix` 开头的同源地址，例如 `/api-proxy/v1/images/generations`。
+   修改配置后需要重新启动开发服务器，并在页面设置中的 `API URL` 填入与 `target` 相同的地址。当前端发现 `API URL` 与 `target` 匹配时，会把请求改写为 `prefix` 开头的同源地址，例如 `/api-proxy/v1/images/generations` 或 `/api-proxy/v1/responses`。
 
    如果需要在线上部署中使用代理，请使用 Vercel Function、Cloudflare Worker、Nginx 反向代理或自建后端等服务端方案。
 
@@ -205,6 +208,10 @@ docker compose up -d
 ## 🛠️ API 配置说明
 
 点击页面右上角的设置图标，你可以随时更改 API 相关的配置。
+
+- **Images API**：调用 `/v1/images/generations` 和 `/v1/images/edits`，模型通常填写 `gpt-image-*`。
+- **Responses API**：调用 `/v1/responses` 并使用 `image_generation` 工具，模型应填写支持该工具的文本模型，而不是 `gpt-image-*`。
+
 应用支持通过 URL 查询参数快速填充配置，非常适合书签或分享给他人使用：
 - `?apiUrl=https://你的代理地址.com`
 - `?apiKey=sk-xxxx`

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -424,6 +424,11 @@ export default function InputBar() {
           className="px-3 py-1.5 rounded-xl border border-gray-200/60 dark:border-white/[0.08] bg-white/50 dark:bg-white/[0.03] focus:outline-none text-xs transition-all duration-200 shadow-sm"
         />
       </label>
+      {settings.apiMode === 'responses' && (
+        <div className="col-span-full text-[10px] text-gray-400 dark:text-gray-500 ml-1">
+          Responses 模式会忽略审核参数；数量大于 1 时会发起多次请求。
+        </div>
+      )}
     </div>
   )
 

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -23,8 +23,10 @@ export default function SettingsModal() {
   }, [showSettings, settings])
 
   const commitSettings = (nextDraft: AppSettings) => {
+    const apiMode = nextDraft.apiMode === 'responses' ? 'responses' : DEFAULT_SETTINGS.apiMode
     const normalizedDraft = {
       ...nextDraft,
+      apiMode,
       baseUrl: normalizeBaseUrl(nextDraft.baseUrl.trim() || DEFAULT_SETTINGS.baseUrl),
       apiKey: nextDraft.apiKey,
       model: nextDraft.model.trim() || DEFAULT_SETTINGS.model,
@@ -157,13 +159,31 @@ export default function SettingsModal() {
               </div>
 
               <label className="block">
-                <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">模型 ID</span>
+                <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">API 接口</span>
+                <select
+                  value={draft.apiMode ?? DEFAULT_SETTINGS.apiMode}
+                  onChange={(e) => {
+                    const nextDraft = { ...draft, apiMode: e.target.value as AppSettings['apiMode'] }
+                    setDraft(nextDraft)
+                    commitSettings(nextDraft)
+                  }}
+                  className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                >
+                  <option value="images">Images API (/v1/images)</option>
+                  <option value="responses">Responses API (/v1/responses)</option>
+                </select>
+              </label>
+
+              <label className="block">
+                <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">
+                  模型 ID{(draft.apiMode ?? DEFAULT_SETTINGS.apiMode) === 'responses' ? '（Responses 文本模型）' : ''}
+                </span>
                 <input
                   value={draft.model}
                   onChange={(e) => setDraft((prev) => ({ ...prev, model: e.target.value }))}
                   onBlur={(e) => commitSettings({ ...draft, model: e.target.value })}
                   type="text"
-                  placeholder="gpt-image-2"
+                  placeholder={(draft.apiMode ?? DEFAULT_SETTINGS.apiMode) === 'responses' ? '支持 image_generation 的文本模型' : DEFAULT_SETTINGS.model}
                   className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                 />
               </label>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { AppSettings, ImageApiResponse, TaskParams } from '../types'
+import type { AppSettings, ImageApiResponse, ResponsesApiResponse, TaskParams } from '../types'
 import { buildApiUrl, readClientDevProxyConfig } from './devProxy'
 
 const MIME_MAP: Record<string, string> = {
@@ -42,6 +42,103 @@ async function fetchImageUrlAsDataUrl(url: string, fallbackMime: string, signal:
   return blobToDataUrl(await response.blob(), fallbackMime)
 }
 
+async function getApiErrorMessage(response: Response): Promise<string> {
+  let errorMsg = `HTTP ${response.status}`
+  try {
+    const errJson = await response.json()
+    if (errJson.error?.message) errorMsg = errJson.error.message
+    else if (errJson.message) errorMsg = errJson.message
+  } catch {
+    try {
+      errorMsg = await response.text()
+    } catch {
+      /* ignore */
+    }
+  }
+  return errorMsg
+}
+
+function createRequestHeaders(settings: AppSettings): Record<string, string> {
+  return {
+    Authorization: `Bearer ${settings.apiKey}`,
+    'Cache-Control': 'no-store, no-cache, max-age=0',
+    Pragma: 'no-cache',
+  }
+}
+
+function createResponsesImageTool(params: TaskParams, isEdit: boolean): Record<string, unknown> {
+  const tool: Record<string, unknown> = {
+    type: 'image_generation',
+    action: isEdit ? 'edit' : 'generate',
+    size: params.size,
+    quality: params.quality,
+    format: params.output_format,
+  }
+
+  if (params.output_format !== 'png' && params.output_compression != null) {
+    tool.compression = params.output_compression
+  }
+
+  return tool
+}
+
+function createResponsesInput(prompt: string, inputImageDataUrls: string[]): unknown {
+  if (!inputImageDataUrls.length) return prompt
+
+  return [
+    {
+      role: 'user',
+      content: [
+        { type: 'input_text', text: prompt.trim() || 'Edit the provided image.' },
+        ...inputImageDataUrls.map((dataUrl) => ({
+          type: 'input_image',
+          image_url: dataUrl,
+        })),
+      ],
+    },
+  ]
+}
+
+function parseResponsesImageDataUrls(payload: ResponsesApiResponse, fallbackMime: string): string[] {
+  const output = payload.output
+  if (!Array.isArray(output) || !output.length) {
+    throw new Error('接口未返回图片数据')
+  }
+
+  const images: string[] = []
+
+  for (const item of output) {
+    if (item?.type !== 'image_generation_call') continue
+
+    const result = item.result
+    if (typeof result === 'string' && result.trim()) {
+      images.push(normalizeBase64Image(result, fallbackMime))
+      continue
+    }
+
+    if (result && typeof result === 'object') {
+      const b64 =
+        typeof result.b64_json === 'string'
+          ? result.b64_json
+          : typeof result.image === 'string'
+            ? result.image
+            : typeof result.data === 'string'
+              ? result.data
+              : null
+
+      if (b64) {
+        images.push(normalizeBase64Image(b64, fallbackMime))
+      }
+    }
+  }
+
+  if (!images.length) {
+    throw new Error('接口未返回可用图片数据')
+  }
+
+  return images
+}
+
 export interface CallApiOptions {
   settings: AppSettings
   prompt: string
@@ -56,15 +153,17 @@ export interface CallApiResult {
 }
 
 export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult> {
+  return opts.settings.apiMode === 'responses'
+    ? callResponsesImageApi(opts)
+    : callImagesApi(opts)
+}
+
+async function callImagesApi(opts: CallApiOptions): Promise<CallApiResult> {
   const { settings, prompt, params, inputImageDataUrls } = opts
   const isEdit = inputImageDataUrls.length > 0
   const mime = MIME_MAP[params.output_format] || 'image/png'
   const proxyConfig = readClientDevProxyConfig()
-  const requestHeaders = {
-    Authorization: `Bearer ${settings.apiKey}`,
-    'Cache-Control': 'no-store, no-cache, max-age=0',
-    Pragma: 'no-cache',
-  }
+  const requestHeaders = createRequestHeaders(settings)
 
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), settings.timeout * 1000)
@@ -130,19 +229,7 @@ export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult>
     }
 
     if (!response.ok) {
-      let errorMsg = `HTTP ${response.status}`
-      try {
-        const errJson = await response.json()
-        if (errJson.error?.message) errorMsg = errJson.error.message
-        else if (errJson.message) errorMsg = errJson.message
-      } catch {
-        try {
-          errorMsg = await response.text()
-        } catch {
-          /* ignore */
-        }
-      }
-      throw new Error(errorMsg)
+      throw new Error(await getApiErrorMessage(response))
     }
 
     const payload = await response.json() as ImageApiResponse
@@ -166,6 +253,50 @@ export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult>
 
     if (!images.length) {
       throw new Error('接口未返回可用图片数据')
+    }
+
+    return { images }
+  } finally {
+    clearTimeout(timeoutId)
+  }
+}
+
+async function callResponsesImageApi(opts: CallApiOptions): Promise<CallApiResult> {
+  const { settings, prompt, params, inputImageDataUrls } = opts
+  const mime = MIME_MAP[params.output_format] || 'image/png'
+  const proxyConfig = readClientDevProxyConfig()
+  const requestHeaders = createRequestHeaders(settings)
+  const controller = new AbortController()
+  const timeoutId = setTimeout(() => controller.abort(), settings.timeout * 1000)
+  const requestCount = Number.isFinite(params.n) ? Math.max(1, Math.floor(params.n)) : 1
+
+  try {
+    const images: string[] = []
+
+    for (let i = 0; i < requestCount; i++) {
+      const body = {
+        model: settings.model,
+        input: createResponsesInput(prompt, inputImageDataUrls),
+        tools: [createResponsesImageTool(params, inputImageDataUrls.length > 0)],
+      }
+
+      const response = await fetch(buildApiUrl(settings.baseUrl, 'responses', proxyConfig), {
+        method: 'POST',
+        headers: {
+          ...requestHeaders,
+          'Content-Type': 'application/json',
+        },
+        cache: 'no-store',
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+
+      if (!response.ok) {
+        throw new Error(await getApiErrorMessage(response))
+      }
+
+      const payload = await response.json() as ResponsesApiResponse
+      images.push(...parseResponsesImageDataUrls(payload, mime))
     }
 
     return { images }

--- a/src/lib/devProxy.ts
+++ b/src/lib/devProxy.ts
@@ -16,7 +16,8 @@ export function normalizeBaseUrl(baseUrl: string): string {
 
   try {
     const url = new URL(input)
-    return `${url.protocol}//${url.host}`
+    const pathname = url.pathname === '/' ? '' : url.pathname.replace(/\/+$/, '')
+    return `${url.origin}${pathname}`
   } catch {
     return trimmed.replace(/\/+$/, '')
   }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,11 +7,17 @@ import { installMobileViewportGuards } from './lib/viewport'
 installMobileViewportGuards()
 
 if ('serviceWorker' in navigator) {
-  window.addEventListener('load', () => {
-    navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch((error) => {
-      console.error('Service worker registration failed:', error)
+  if (import.meta.env.PROD) {
+    window.addEventListener('load', () => {
+      navigator.serviceWorker.register(`${import.meta.env.BASE_URL}sw.js`).catch((error) => {
+        console.error('Service worker registration failed:', error)
+      })
     })
-  })
+  } else {
+    navigator.serviceWorker.getRegistrations().then((registrations) => {
+      registrations.forEach((registration) => registration.unregister())
+    })
+  }
 }
 
 createRoot(document.getElementById('root')!).render(

--- a/src/store.ts
+++ b/src/store.ts
@@ -101,7 +101,16 @@ export const useStore = create<AppState>()(
     (set, get) => ({
       // Settings
       settings: { ...DEFAULT_SETTINGS },
-      setSettings: (s) => set((st) => ({ settings: { ...st.settings, ...s } })),
+      setSettings: (s) => set((st) => ({
+        settings: {
+          ...st.settings,
+          ...s,
+          apiMode:
+            s.apiMode === 'images' || s.apiMode === 'responses'
+              ? s.apiMode
+              : st.settings.apiMode ?? DEFAULT_SETTINGS.apiMode,
+        },
+      })),
 
       // Input
       prompt: '',

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,13 @@
 // ===== 设置 =====
 
+export type ApiMode = 'images' | 'responses'
+
 export interface AppSettings {
   baseUrl: string
   apiKey: string
   model: string
   timeout: number
+  apiMode: ApiMode
 }
 
 const DEFAULT_BASE_URL = import.meta.env.VITE_DEFAULT_API_URL?.trim() || 'https://api.openai.com'
@@ -14,6 +17,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   apiKey: '',
   model: 'gpt-image-2',
   timeout: 300,
+  apiMode: 'images',
 }
 
 // ===== 任务参数 =====
@@ -98,6 +102,19 @@ export interface ImageResponseItem {
 
 export interface ImageApiResponse {
   data: ImageResponseItem[]
+}
+
+export interface ResponsesOutputItem {
+  type?: string
+  result?: string | {
+    b64_json?: string
+    image?: string
+    data?: string
+  }
+}
+
+export interface ResponsesApiResponse {
+  output?: ResponsesOutputItem[]
 }
 
 // ===== 导出数据 =====


### PR DESCRIPTION
Add an API mode selector for Images API and Responses API, map existing image parameters to the Responses image_generation tool, and normalize Responses outputs into the existing task image flow.

Also preserve path prefixes in API URLs and disable service worker registration during development.