### PR TITLE
fix: parse streamed Responses image events

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -227,6 +227,32 @@ export default function SettingsModal() {
                 </div>
               </label>
 
+              {(draft.apiMode ?? DEFAULT_SETTINGS.apiMode) === 'responses' && (
+                <div className="flex items-start justify-between gap-3 rounded-xl border border-gray-200/70 bg-white/40 px-3 py-2.5 dark:border-white/[0.08] dark:bg-white/[0.03]">
+                  <div>
+                    <div className="text-xs font-medium text-gray-600 dark:text-gray-300">流式生图响应</div>
+                    <div className="mt-1 text-[10px] leading-relaxed text-gray-400 dark:text-gray-500">
+                      可缓解部分中转/反代的长时间无响应超时；如果接口不支持流式响应，可关闭。
+                    </div>
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      const nextDraft = { ...draft, responsesStream: !draft.responsesStream }
+                      setDraft(nextDraft)
+                      commitSettings(nextDraft)
+                    }}
+                    className="mt-0.5 flex shrink-0 items-center"
+                    role="switch"
+                    aria-checked={draft.responsesStream ?? DEFAULT_SETTINGS.responsesStream}
+                  >
+                    <span className={`relative inline-flex h-5 w-9 items-center rounded-full transition-colors ${draft.responsesStream ?? DEFAULT_SETTINGS.responsesStream ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}>
+                      <span className={`inline-block h-4 w-4 transform rounded-full bg-white shadow transition-transform ${draft.responsesStream ?? DEFAULT_SETTINGS.responsesStream ? 'translate-x-4' : 'translate-x-0.5'}`} />
+                    </span>
+                  </button>
+                </div>
+              )}
+
               <label className="block">
                 <span className="block text-xs text-gray-500 dark:text-gray-400 mb-1">请求超时 (秒)</span>
                 <input

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,5 +1,6 @@
 import type { AppSettings, ImageApiResponse, ResponsesApiResponse, TaskParams } from '../types'
 import { buildApiUrl, readClientDevProxyConfig } from './devProxy'
+import { extractGeneratedImageBase64, findGeneratedImagePayload, readResponsesStreamPayload } from './responsesStream'
 
 const MIME_MAP: Record<string, string> = {
   png: 'image/png',
@@ -152,6 +153,31 @@ function parseResponsesImageResults(payload: ResponsesApiResponse, fallbackMime:
   }
 
   return results
+}
+
+function parseResponsesImageResultsFromUnknown(payload: unknown, fallbackMime: string): Array<{
+  image: string
+  actualParams?: Partial<TaskParams>
+  revisedPrompt?: string
+}> {
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('接口未返回图片数据')
+  }
+
+  const imagePayload = findGeneratedImagePayload(payload)
+  const image = extractGeneratedImageBase64(imagePayload)
+  if (image) {
+    return [{
+      image: normalizeBase64Image(image, fallbackMime),
+      actualParams: mergeActualParams(pickActualParams(imagePayload)),
+      revisedPrompt:
+        imagePayload && typeof imagePayload.revised_prompt === 'string'
+          ? imagePayload.revised_prompt
+          : undefined,
+    }]
+  }
+
+  return parseResponsesImageResults(payload as ResponsesApiResponse, fallbackMime)
 }
 
 function pickActualParams(source: unknown): Partial<TaskParams> {
@@ -396,6 +422,7 @@ async function callResponsesImageApiSingle(opts: CallApiOptions): Promise<CallAp
       input: createResponsesInput(prompt, inputImageDataUrls),
       tools: [createResponsesImageTool(params, inputImageDataUrls.length > 0, settings)],
       tool_choice: 'required',
+      stream: settings.responsesStream,
     }
 
     const response = await fetch(buildApiUrl(settings.baseUrl, 'responses', proxyConfig), {
@@ -413,8 +440,10 @@ async function callResponsesImageApiSingle(opts: CallApiOptions): Promise<CallAp
       throw new Error(await getApiErrorMessage(response))
     }
 
-    const payload = await response.json() as ResponsesApiResponse
-    const imageResults = parseResponsesImageResults(payload, mime)
+    const payload = settings.responsesStream
+      ? (await readResponsesStreamPayload(response)).payload
+      : await response.json() as ResponsesApiResponse
+    const imageResults = parseResponsesImageResultsFromUnknown(payload, mime)
     const actualParams = mergeActualParams(
       imageResults[0]?.actualParams ?? {},
       settings.codexCli ? { quality: 'auto' } : {},

--- a/src/lib/responsesStream.ts
+++ b/src/lib/responsesStream.ts
@@ -1,0 +1,191 @@
+export interface ResponsesStreamEvent {
+  event: string
+  data: string
+}
+
+export type ResponsesStreamPayloadSource = 'partial' | 'final' | 'completed' | 'latest'
+
+export interface ResponsesStreamPayloadResult {
+  payload: unknown | null
+  source: ResponsesStreamPayloadSource
+}
+
+export function parseServerSentEvent(rawEvent: string): ResponsesStreamEvent {
+  const lines = rawEvent.split(/\r?\n/)
+  const dataLines: string[] = []
+  let event = ''
+
+  for (const line of lines) {
+    if (line.startsWith('event:')) {
+      event = line.slice('event:'.length).trim()
+    }
+
+    if (line.startsWith('data:')) {
+      dataLines.push(line.slice('data:'.length).trimStart())
+    }
+  }
+
+  return {
+    event,
+    data: dataLines.join('\n'),
+  }
+}
+
+export function parseJsonOrNull(value: string): unknown | null {
+  try {
+    return JSON.parse(value) as unknown
+  } catch {
+    return null
+  }
+}
+
+function readString(record: Record<string, unknown>, key: string): string | null {
+  const value = record[key]
+  return typeof value === 'string' && value.trim() ? value : null
+}
+
+function getDirectImageBase64(record: Record<string, unknown>): string | null {
+  const result = readString(record, 'result')
+  if (result) return result
+
+  const partialImage = readString(record, 'partial_image_b64')
+  if (partialImage) return partialImage
+
+  const b64Json = readString(record, 'b64_json')
+  if (b64Json) return b64Json
+
+  return null
+}
+
+export function extractGeneratedImageBase64(payload: unknown): string | null {
+  if (!payload || typeof payload !== 'object') return null
+
+  const record = payload as Record<string, unknown>
+  const directImage = getDirectImageBase64(record)
+  if (directImage) return directImage
+
+  const itemImage = extractGeneratedImageBase64(record.item)
+  if (itemImage) return itemImage
+
+  const responseImage = extractGeneratedImageBase64(record.response)
+  if (responseImage) return responseImage
+
+  if (Array.isArray(record.output)) {
+    for (const item of record.output) {
+      const outputImage = extractGeneratedImageBase64(item)
+      if (outputImage) return outputImage
+    }
+  }
+
+  return null
+}
+
+function hasFinalImagePayload(payload: unknown): boolean {
+  if (!payload || typeof payload !== 'object') return false
+  const record = payload as Record<string, unknown>
+  return Boolean(readString(record, 'result') || readString(record, 'b64_json'))
+}
+
+export function findGeneratedImagePayload(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== 'object') return null
+
+  const record = payload as Record<string, unknown>
+  const itemPayload = findGeneratedImagePayload(record.item)
+  if (itemPayload) return itemPayload
+
+  const responsePayload = findGeneratedImagePayload(record.response)
+  if (responsePayload) return responsePayload
+
+  if (Array.isArray(record.output)) {
+    for (const item of record.output) {
+      const outputPayload = findGeneratedImagePayload(item)
+      if (outputPayload) return outputPayload
+    }
+  }
+
+  if (extractGeneratedImageBase64(record)) return record
+
+  return null
+}
+
+function pickCompletedPayload(event: ResponsesStreamEvent, payload: unknown): unknown | null {
+  if (!payload || typeof payload !== 'object') return null
+
+  const record = payload as Record<string, unknown>
+  if (event.event === 'response.completed' || record.type === 'response.completed') {
+    return record.response || record
+  }
+
+  return null
+}
+
+function chooseStreamPayload(
+  partialPayload: unknown | null,
+  finalPayload: unknown | null,
+  completedPayload: unknown | null,
+  latestPayload: unknown | null,
+): ResponsesStreamPayloadResult {
+  if (finalPayload) return { payload: finalPayload, source: 'final' }
+  if (completedPayload && extractGeneratedImageBase64(completedPayload)) return { payload: completedPayload, source: 'completed' }
+  if (partialPayload) return { payload: partialPayload, source: 'partial' }
+  if (completedPayload) return { payload: completedPayload, source: 'completed' }
+  return { payload: latestPayload, source: 'latest' }
+}
+
+export async function readResponsesStreamPayload(response: Response): Promise<ResponsesStreamPayloadResult> {
+  if (!response.body) return { payload: null, source: 'latest' }
+
+  const decoder = new TextDecoder()
+  let buffer = ''
+  let latestPayload: unknown | null = null
+  let completedPayload: unknown | null = null
+  let partialPayload: unknown | null = null
+  let finalPayload: unknown | null = null
+
+  const processRawEvent = (rawEvent: string) => {
+    const event = parseServerSentEvent(rawEvent)
+    if (!event.data || event.data === '[DONE]') return
+
+    const payload = parseJsonOrNull(event.data)
+    if (!payload) return
+
+    latestPayload = payload
+
+    if (extractGeneratedImageBase64(payload)) {
+      if (hasFinalImagePayload(findGeneratedImagePayload(payload))) {
+        finalPayload = payload
+      } else {
+        partialPayload = payload
+      }
+    }
+
+    const completed = pickCompletedPayload(event, payload)
+    if (completed) {
+      completedPayload = completed
+    }
+  }
+
+  const reader = response.body.getReader()
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    buffer += decoder.decode(value, { stream: true })
+
+    const parts = buffer.split(/\r?\n\r?\n/)
+    buffer = parts.pop() || ''
+
+    for (const part of parts) {
+      processRawEvent(part)
+    }
+  }
+
+  const trailing = decoder.decode()
+  if (trailing) buffer += trailing
+
+  if (buffer.trim()) {
+    processRawEvent(buffer)
+  }
+
+  return chooseStreamPayload(partialPayload, finalPayload, completedPayload, latestPayload)
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -124,6 +124,7 @@ export const useStore = create<AppState>()(
               ? s.apiMode
               : st.settings.apiMode ?? DEFAULT_SETTINGS.apiMode,
           codexCli: s.codexCli ?? st.settings.codexCli ?? DEFAULT_SETTINGS.codexCli,
+          responsesStream: s.responsesStream ?? st.settings.responsesStream ?? DEFAULT_SETTINGS.responsesStream,
         },
       })),
       dismissedCodexCliPrompts: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,7 @@ export interface AppSettings {
   timeout: number
   apiMode: ApiMode
   codexCli: boolean
+  responsesStream: boolean
 }
 
 const DEFAULT_BASE_URL = import.meta.env.VITE_DEFAULT_API_URL?.trim() || 'https://api.openai.com/v1'
@@ -22,6 +23,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   timeout: 300,
   apiMode: 'images',
   codexCli: false,
+  responsesStream: true,
 }
 
 // ===== 任务参数 =====

--- a/tests/responsesStream.test.ts
+++ b/tests/responsesStream.test.ts
@@ -1,0 +1,101 @@
+import { strict as assert } from 'node:assert'
+import test from 'node:test'
+import { extractGeneratedImageBase64, findGeneratedImagePayload, readResponsesStreamPayload } from '../src/lib/responsesStream.ts'
+
+function responseFromSse(chunks: string[]): Response {
+  const encoder = new TextEncoder()
+  return new Response(
+    new ReadableStream({
+      start(controller) {
+        for (const chunk of chunks) controller.enqueue(encoder.encode(chunk))
+        controller.close()
+      },
+    }),
+  )
+}
+
+test('falls back to partial image when completed output is empty', async () => {
+  const result = await readResponsesStreamPayload(
+    responseFromSse([
+      'event: response.image_generation_call.partial_image\n',
+      'data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"partial-one"}\n\n',
+      'event: response.completed\n',
+      'data: {"type":"response.completed","response":{"output":[]}}\n\n',
+    ]),
+  )
+
+  assert.equal(result.source, 'partial')
+  assert.equal(extractGeneratedImageBase64(result.payload), 'partial-one')
+})
+
+test('extracts image data from output_item.done events', async () => {
+  const result = await readResponsesStreamPayload(
+    responseFromSse([
+      'event: response.output_item.done\n',
+      'data: {"type":"response.output_item.done","item":{"type":"image_generation_call","result":"final-image"}}\n\n',
+      'data: [DONE]\n\n',
+    ]),
+  )
+
+  assert.equal(result.source, 'final')
+  assert.equal(extractGeneratedImageBase64(result.payload), 'final-image')
+})
+
+test('finds the concrete image payload nested inside output_item.done', async () => {
+  const result = await readResponsesStreamPayload(
+    responseFromSse([
+      'event: response.output_item.done\n',
+      'data: {"type":"response.output_item.done","item":{"type":"image_generation_call","result":"final-image","quality":"high"}}\n\n',
+    ]),
+  )
+
+  assert.deepEqual(findGeneratedImagePayload(result.payload), {
+    type: 'image_generation_call',
+    result: 'final-image',
+    quality: 'high',
+  })
+})
+
+test('prefers final image over earlier partial image', async () => {
+  const result = await readResponsesStreamPayload(
+    responseFromSse([
+      'event: response.image_generation_call.partial_image\n',
+      'data: {"type":"response.image_generation_call.partial_image","partial_image_b64":"partial-one"}\n\n',
+      'event: response.output_item.done\n',
+      'data: {"type":"response.output_item.done","item":{"type":"image_generation_call","result":"final-image"}}\n\n',
+    ]),
+  )
+
+  assert.equal(result.source, 'final')
+  assert.equal(extractGeneratedImageBase64(result.payload), 'final-image')
+})
+
+test('handles SSE event split across chunks', async () => {
+  const result = await readResponsesStreamPayload(
+    responseFromSse([
+      'event: response.output_item.done\n',
+      'data: {"type":"response.output_item.done","item":',
+      '{"type":"image_generation_call","result":"final-image"}}\n\n',
+    ]),
+  )
+
+  assert.equal(result.source, 'final')
+  assert.equal(extractGeneratedImageBase64(result.payload), 'final-image')
+})
+
+test('extracts image data from completed output when present', () => {
+  const base64 = extractGeneratedImageBase64({
+    output: [{ type: 'image_generation_call', result: 'completed-image' }],
+  })
+
+  assert.equal(base64, 'completed-image')
+})
+
+test('extracts image data from b64_json compatibility payloads', () => {
+  const base64 = extractGeneratedImageBase64({
+    type: 'image_generation.completed',
+    b64_json: 'completed-image',
+  })
+
+  assert.equal(base64, 'completed-image')
+})


### PR DESCRIPTION
## 背景

关联 #7。

长时间图片生成失败通常有两类场景：

1. 自建 Nginx/OpenResty/1Panel 反代时，Images API 非流式请求可能因为 `proxy_read_timeout` 等配置较短，在 60 秒左右返回 504。这个场景仍然应优先通过提高反代超时解决。

2. 使用第三方 OpenAI 兼容中转时，调用方无法修改对方网关配置。复杂图片生成可能超过代理层空闲超时，非流式请求会在最终 JSON 返回前被断开。

本 PR 主要补充第二类场景的前端兼容方案：在 Responses API 下支持流式响应，并从 SSE 事件中提取图片数据。

## 改动

- 为 Responses API 增加“流式生图响应”设置项
  - 默认开启
  - 可在设置中关闭，以兼容不支持流式响应的中转
- Responses API 流式开启时，请求体增加 `stream: true`
- 流式文生图时，请求 `partial_images: 1`
- 新增 SSE 事件解析逻辑
- 支持从以下事件/字段中提取图片 base64：
  - `response.output_item.done`
  - `response.image_generation_call.partial_image`
  - `response.completed`
  - `result`
  - `partial_image_b64`
  - `b64_json`
- 优先使用最终图片结果
- 如果没有最终图片，但流中出现过 partial image，则将 partial image 作为 fallback
- 保留非流式 Responses API 的原有 JSON 解析路径

## 行为说明

这个 PR 不改变 Images API `/v1/images/generations` 的行为。

对于 Images API 的 504 问题，仍然需要调整网关超时，例如：

```nginx
proxy_connect_timeout 300s;
proxy_send_timeout    300s;
proxy_read_timeout    600s;
send_timeout          600s;
