### PR TITLE
Add mask editor for image edits

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "postcss": "^8.5.3",
         "tailwindcss": "^3.4.17",
         "typescript": "^5.8.3",
-        "vite": "^6.3.2"
+        "vite": "^6.3.2",
+        "vitest": "^4.1.5"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1206,6 +1207,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1250,6 +1258,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -1299,6 +1325,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.5.tgz",
+      "integrity": "sha512-PWBaRY5JoKuRnHlUHfpV/KohFylaDZTupcXN1H9vYryNLOnitSw60Mw9IAE2r67NbwwzBw/Cc/8q9BK3kIX8Kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.5.tgz",
+      "integrity": "sha512-/x2EmFC4mT4NNzqvC3fmesuV97w5FC903KPmey4gsnJiMQ3Be1IlDKVaDaG8iqaLFHqJ2FVEkxZk5VmeLjIItw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.5",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.5.tgz",
+      "integrity": "sha512-7I3q6l5qr03dVfMX2wCo9FxwSJbPdwKjy2uu/YPpU3wfHvIL4QHwVRp57OfGrDFeUJ8/8QdfBKIV12FTtLn00g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.5.tgz",
+      "integrity": "sha512-2D+o7Pr82IEO46YPpoA/YU0neeyr6FTerQb5Ro7BUnBuv6NQtT/kmVnczngiMEBhzgqz2UZYl5gArejsyERDSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.5",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.5.tgz",
+      "integrity": "sha512-zypXEt4KH/XgKGPUz4eC2AvErYx0My5hfL8oDb1HzGFpEk1P62bxSohdyOmvz+d9UJwanI68MKwr2EquOaOgMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.5.tgz",
+      "integrity": "sha512-2lNOsh6+R2Idnf1TCZqSwYlKN2E/iDlD8sgU59kYVl+OMDmvldO1VDk39smRfpUNwYpNRVn3w4YfuC7KfbBnkQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.5.tgz",
+      "integrity": "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.5",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/any-promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
@@ -1326,6 +1465,16 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
@@ -1468,6 +1617,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -1592,6 +1751,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1642,6 +1808,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-glob": {
@@ -1913,6 +2099,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -2012,10 +2208,28 @@
         "node": ">= 6"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -2415,6 +2629,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2424,6 +2645,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -2522,6 +2757,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -2568,6 +2820,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -2746,6 +3008,126 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.5.tgz",
+      "integrity": "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.5",
+        "@vitest/mocker": "4.1.5",
+        "@vitest/pretty-format": "4.1.5",
+        "@vitest/runner": "4.1.5",
+        "@vitest/snapshot": "4.1.5",
+        "@vitest/spy": "4.1.5",
+        "@vitest/utils": "4.1.5",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.5",
+        "@vitest/browser-preview": "4.1.5",
+        "@vitest/browser-webdriverio": "4.1.5",
+        "@vitest/coverage-istanbul": "4.1.5",
+        "@vitest/coverage-v8": "4.1.5",
+        "@vitest/ui": "4.1.5",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "fflate": "^0.8.2",
@@ -22,6 +24,7 @@
     "postcss": "^8.5.3",
     "tailwindcss": "^3.4.17",
     "typescript": "^5.8.3",
-    "vite": "^6.3.2"
+    "vite": "^6.3.2",
+    "vitest": "^4.1.5"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import SettingsModal from './components/SettingsModal'
 import ConfirmDialog from './components/ConfirmDialog'
 import Toast from './components/Toast'
 import ImageContextMenu from './components/ImageContextMenu'
+import MaskEditorModal from './components/MaskEditorModal'
 
 export default function App() {
   const setSettings = useStore((s) => s.setSettings)
@@ -85,6 +86,7 @@ export default function App() {
       <ConfirmDialog />
       <Toast />
       <ImageContextMenu />
+      <MaskEditorModal />
     </>
   )
 }

--- a/src/components/DetailModal.tsx
+++ b/src/components/DetailModal.tsx
@@ -4,6 +4,7 @@ import { useCloseOnEscape } from '../hooks/useCloseOnEscape'
 import { formatImageRatio } from '../lib/size'
 import { ActualValueBadge, DetailParamValue } from '../lib/paramDisplay'
 import { copyBlobToClipboard, copyTextToClipboard, getClipboardFailureMessage } from '../lib/clipboard'
+import { createMaskPreviewDataUrl } from '../lib/canvasImage'
 
 export default function DetailModal() {
   const tasks = useStore((s) => s.tasks)
@@ -17,6 +18,7 @@ export default function DetailModal() {
   const [imageSrcs, setImageSrcs] = useState<Record<string, string>>({})
   const [imageRatios, setImageRatios] = useState<Record<string, string>>({})
   const [imageSizes, setImageSizes] = useState<Record<string, string>>({})
+  const [maskPreviewSrc, setMaskPreviewSrc] = useState('')
   const imagePanelRef = useRef<HTMLDivElement>(null)
   const mainImageRef = useRef<HTMLImageElement>(null)
   const [imageLabelLeft, setImageLabelLeft] = useState(8)
@@ -36,7 +38,11 @@ export default function DetailModal() {
   // 加载所有相关图片
   useEffect(() => {
     if (!task) return
-    const ids = [...(task.outputImages || []), ...(task.inputImageIds || [])]
+    const ids = [
+      ...(task.outputImages || []),
+      ...(task.inputImageIds || []),
+      ...(task.maskImageId ? [task.maskImageId] : []),
+    ]
     for (const id of ids) {
       const cached = getCachedImage(id)
       if (cached) {
@@ -51,6 +57,10 @@ export default function DetailModal() {
 
   const currentOutputImageId = task?.outputImages?.[imageIndex] || ''
   const currentOutputImageSrc = currentOutputImageId ? imageSrcs[currentOutputImageId] || '' : ''
+  const maskTargetId = task?.maskTargetImageId || null
+  const maskTargetSrc = maskTargetId ? imageSrcs[maskTargetId] || '' : ''
+  const maskSrc = task?.maskImageId ? imageSrcs[task.maskImageId] || '' : ''
+  const referenceInputImageIds = task?.inputImageIds?.filter((id) => id !== maskTargetId) ?? []
 
   useEffect(() => {
     if (!currentOutputImageId || !currentOutputImageSrc) return
@@ -101,6 +111,26 @@ export default function DetailModal() {
     window.addEventListener('resize', updateImageLabelLeft)
     return () => window.removeEventListener('resize', updateImageLabelLeft)
   }, [currentOutputImageSrc])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!maskTargetSrc || !maskSrc) {
+      setMaskPreviewSrc('')
+      return
+    }
+
+    createMaskPreviewDataUrl(maskTargetSrc, maskSrc)
+      .then((url) => {
+        if (!cancelled) setMaskPreviewSrc(url)
+      })
+      .catch(() => {
+        if (!cancelled) setMaskPreviewSrc('')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [maskTargetSrc, maskSrc])
 
   if (!task) return null
 
@@ -380,12 +410,35 @@ export default function DetailModal() {
               </div>
             )}
 
+            {/* 遮罩 */}
+            {maskTargetSrc && maskSrc && (
+              <div className="mb-4">
+                <h3 className="mb-2 text-xs font-medium uppercase tracking-wider text-gray-400 dark:text-gray-500">
+                  遮罩编辑
+                </h3>
+                <div className="flex items-center gap-3 rounded-2xl border border-orange-200/80 bg-orange-50/80 p-3 text-xs text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-200">
+                  <img
+                    src={maskPreviewSrc || maskTargetSrc}
+                    className="h-20 w-20 rounded-xl border border-orange-200/80 object-cover dark:border-orange-500/20"
+                    onClick={() => setLightboxImageId(maskTargetId || '', task.inputImageIds)}
+                    alt=""
+                  />
+                  <div className="leading-relaxed">
+                    <div className="font-medium">橙色区域将被编辑</div>
+                    <div className="mt-1 opacity-80">
+                      这张图在提交时被固定为第 1 张输入图；其余图片只作为参考图。
+                    </div>
+                  </div>
+                </div>
+              </div>
+            )}
+
             {/* 参考图 */}
             {task.inputImageIds?.length > 0 && (
               <div className="mb-4">
                 <div className="flex items-center gap-1.5 mb-2">
                   <h3 className="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
-                    参考图
+                    {task.maskImageId ? '其他参考图' : '参考图'}
                   </h3>
                   <button
                     onClick={handleCopyInputImage}
@@ -398,7 +451,7 @@ export default function DetailModal() {
                   </button>
                 </div>
                 <div className="flex gap-2 flex-wrap">
-                  {task.inputImageIds.map((imgId) => (
+                  {(task.maskImageId ? referenceInputImageIds : task.inputImageIds).map((imgId) => (
                     <img
                       key={imgId}
                       src={imageSrcs[imgId] || ''}
@@ -407,6 +460,9 @@ export default function DetailModal() {
                       alt=""
                     />
                   ))}
+                  {task.maskImageId && referenceInputImageIds.length === 0 && (
+                    <span className="text-xs text-gray-400 dark:text-gray-500">无其他参考图</span>
+                  )}
                 </div>
               </div>
             )}

--- a/src/components/DetailModal.tsx
+++ b/src/components/DetailModal.tsx
@@ -451,15 +451,23 @@ export default function DetailModal() {
                   </button>
                 </div>
                 <div className="flex gap-2 flex-wrap">
-                  {(task.maskImageId ? referenceInputImageIds : task.inputImageIds).map((imgId) => (
-                    <img
-                      key={imgId}
-                      src={imageSrcs[imgId] || ''}
-                      className="w-16 h-16 rounded-lg object-cover border border-gray-200 dark:border-white/[0.08] cursor-pointer hover:opacity-80 transition"
-                      onClick={() => setLightboxImageId(imgId, task.inputImageIds)}
-                      alt=""
-                    />
-                  ))}
+                  {(task.maskImageId ? referenceInputImageIds : task.inputImageIds).map((imgId) => {
+                    const src = imageSrcs[imgId]
+                    return src ? (
+                      <img
+                        key={imgId}
+                        src={src}
+                        className="w-16 h-16 rounded-lg object-cover border border-gray-200 dark:border-white/[0.08] cursor-pointer hover:opacity-80 transition"
+                        onClick={() => setLightboxImageId(imgId, task.inputImageIds)}
+                        alt=""
+                      />
+                    ) : (
+                      <div
+                        key={imgId}
+                        className="w-16 h-16 rounded-lg border border-gray-200 bg-gray-100 dark:border-white/[0.08] dark:bg-white/[0.04]"
+                      />
+                    )
+                  })}
                   {task.maskImageId && referenceInputImageIds.length === 0 && (
                     <span className="text-xs text-gray-400 dark:text-gray-500">无其他参考图</span>
                   )}

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, useState, useMemo } from 'react'
 import { useStore, submitTask, addImageFromFile, updateTaskInStore, removeMultipleTasks } from '../store'
 import { DEFAULT_PARAMS } from '../types'
 import { normalizeImageSize } from '../lib/size'
+import { createMaskPreviewDataUrl } from '../lib/canvasImage'
 import Select from './Select'
 import SizePickerModal from './SizePickerModal'
 
@@ -37,6 +38,9 @@ export default function InputBar() {
   const inputImages = useStore((s) => s.inputImages)
   const removeInputImage = useStore((s) => s.removeInputImage)
   const clearInputImages = useStore((s) => s.clearInputImages)
+  const maskDraft = useStore((s) => s.maskDraft)
+  const clearMaskDraft = useStore((s) => s.clearMaskDraft)
+  const setMaskEditorImageId = useStore((s) => s.setMaskEditorImageId)
   const params = useStore((s) => s.params)
   const setParams = useStore((s) => s.setParams)
   const settings = useStore((s) => s.settings)
@@ -118,6 +122,7 @@ export default function InputBar() {
   const [qualityHintVisible, setQualityHintVisible] = useState(false)
   const [mobileCollapsed, setMobileCollapsed] = useState(false)
   const [showSizePicker, setShowSizePicker] = useState(false)
+  const [maskPreviewUrl, setMaskPreviewUrl] = useState('')
   const handleRef = useRef<HTMLDivElement>(null)
   const dragTouchRef = useRef({ startY: 0, moved: false })
   const compressionHintTimerRef = useRef<number | null>(null)
@@ -132,6 +137,10 @@ export default function InputBar() {
 
   const canSubmit = prompt.trim() && settings.apiKey
   const atImageLimit = inputImages.length >= API_MAX_IMAGES
+  const maskTargetImage = maskDraft
+    ? inputImages.find((img) => img.id === maskDraft.targetImageId) ?? null
+    : null
+  const referenceImageCount = maskTargetImage ? Math.max(0, inputImages.length - 1) : inputImages.length
 
   useEffect(() => {
     setOutputCompressionInput(
@@ -154,6 +163,26 @@ export default function InputBar() {
       setParams({ quality: 'auto' })
     }
   }, [params.quality, settings.codexCli, setParams])
+
+  useEffect(() => {
+    let cancelled = false
+    if (!maskDraft || !maskTargetImage) {
+      setMaskPreviewUrl('')
+      return
+    }
+
+    createMaskPreviewDataUrl(maskTargetImage.dataUrl, maskDraft.maskDataUrl)
+      .then((url) => {
+        if (!cancelled) setMaskPreviewUrl(url)
+      })
+      .catch(() => {
+        if (!cancelled) setMaskPreviewUrl('')
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [maskDraft, maskTargetImage?.id, maskTargetImage?.dataUrl])
 
   useEffect(() => () => {
     if (compressionHintTimerRef.current != null) {
@@ -407,7 +436,7 @@ export default function InputBar() {
   // 图片队列变化时也重新计算
   useEffect(() => {
     adjustTextareaHeight()
-  }, [inputImages.length, adjustTextareaHeight])
+  }, [inputImages.length, Boolean(maskDraft), maskPreviewUrl, adjustTextareaHeight])
 
   useEffect(() => {
     window.addEventListener('resize', adjustTextareaHeight)
@@ -447,16 +476,40 @@ export default function InputBar() {
   const renderImageThumbs = () => (
     <div ref={imagesRef}>
       <div className="grid grid-cols-[repeat(auto-fill,52px)] justify-between gap-x-2 gap-y-3 mb-3">
-        {inputImages.map((img, idx) => (
+        {inputImages.map((img, idx) => {
+          const isMaskTarget = img.id === maskTargetImage?.id
+          return (
           <div key={img.id} className="relative group inline-block">
-            <div className="relative w-[52px] h-[52px] rounded-xl overflow-hidden border border-gray-200 dark:border-white/[0.08] shadow-sm cursor-pointer">
+            <div
+              className={`relative w-[52px] h-[52px] rounded-xl overflow-hidden border shadow-sm cursor-pointer ${
+                isMaskTarget
+                  ? 'border-orange-400 ring-2 ring-orange-400/30'
+                  : 'border-gray-200 dark:border-white/[0.08]'
+              }`}
+            >
               <img
-                src={img.dataUrl}
+                src={isMaskTarget && maskPreviewUrl ? maskPreviewUrl : img.dataUrl}
                 className="w-full h-full object-cover hover:opacity-90 transition-opacity"
                 onClick={() => setLightboxImageId(img.id, inputImages.map((i) => i.id))}
                 alt=""
               />
+              {isMaskTarget && (
+                <span className="absolute left-1 top-1 rounded-full bg-orange-500 px-1.5 py-0.5 text-[9px] font-medium leading-none text-white shadow-sm">
+                  遮罩
+                </span>
+              )}
             </div>
+            <button
+              type="button"
+              className="absolute -bottom-2 left-1/2 -translate-x-1/2 rounded-full bg-gray-900/85 px-2 py-0.5 text-[9px] font-medium text-white opacity-0 shadow-md transition-opacity hover:bg-orange-500 group-hover:opacity-100"
+              onClick={(e) => {
+                e.stopPropagation()
+                setMaskEditorImageId(img.id)
+              }}
+              title={isMaskTarget ? '编辑遮罩' : '为这张图绘制遮罩'}
+            >
+              {isMaskTarget ? '编辑' : '遮罩'}
+            </button>
             <span
               className="absolute -top-2 -right-2 w-[22px] h-[22px] rounded-full bg-red-500 text-white flex items-center justify-center cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity shadow-md hover:bg-red-600"
               onClick={() => removeInputImage(idx)}
@@ -466,26 +519,41 @@ export default function InputBar() {
               </svg>
             </span>
           </div>
-        ))}
+          )
+        })}
 
         {/* 清空全部按钮 */}
         <button
           onClick={() =>
             setConfirmDialog({
-              title: '清空参考图',
-              message: `确定要清空全部 ${inputImages.length} 张参考图吗？`,
+              title: maskDraft ? '清空全部输入图' : '清空参考图',
+              message: maskDraft
+                ? `确定要清空遮罩主图、遮罩和全部 ${inputImages.length} 张参考图吗？`
+                : `确定要清空全部 ${inputImages.length} 张参考图吗？`,
               action: () => clearInputImages(),
             })
           }
           className="w-[52px] h-[52px] rounded-xl border border-dashed border-gray-300 dark:border-white/[0.08] flex flex-col items-center justify-center gap-0.5 text-gray-400 dark:text-gray-500 hover:text-red-500 hover:border-red-300 hover:bg-red-50/50 dark:hover:bg-red-950/30 transition-all cursor-pointer flex-shrink-0"
-          title="清空全部参考图"
+          title={maskDraft ? '清空遮罩主图、参考图和遮罩' : '清空全部参考图'}
         >
           <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
           </svg>
-          <span className="text-[9px] leading-none">清空</span>
+          <span className="text-[9px] leading-none">{maskDraft ? '清空全部' : '清空'}</span>
         </button>
       </div>
+      {maskDraft && maskTargetImage && (
+        <div className="mb-3 flex items-center justify-between rounded-2xl border border-orange-200/80 bg-orange-50/80 px-3 py-2 text-xs text-orange-700 dark:border-orange-500/20 dark:bg-orange-500/10 dark:text-orange-200">
+          <span>将使用遮罩编辑第 1 张图，另有 {referenceImageCount} 张参考图。</span>
+          <button
+            type="button"
+            onClick={clearMaskDraft}
+            className="rounded-lg px-2 py-1 font-medium transition hover:bg-orange-100 dark:hover:bg-orange-500/20"
+          >
+            取消遮罩
+          </button>
+        </div>
+      )}
     </div>
   )
 
@@ -740,7 +808,11 @@ export default function InputBar() {
                   </div>
                 </div>
                 {mobileCollapsed && (
-                  <div className="text-xs text-gray-400 dark:text-gray-500 mb-2 ml-1">{inputImages.length} 张参考图</div>
+                  <div className="text-xs text-gray-400 dark:text-gray-500 mb-2 ml-1">
+                    {maskDraft && maskTargetImage
+                      ? `1 张遮罩主图 · ${referenceImageCount} 张参考图`
+                      : `${inputImages.length} 张参考图`}
+                  </div>
                 )}
               </>
             ) : (
@@ -800,7 +872,7 @@ export default function InputBar() {
                         ? 'bg-gray-300 dark:bg-white/[0.06] text-white cursor-pointer'
                         : 'bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-white/[0.04] disabled:opacity-50 disabled:cursor-not-allowed'
                     }`}
-                    title={settings.apiKey ? '生成 (Ctrl+Enter)' : '请先配置 API'}
+                    title={settings.apiKey ? (maskDraft ? '遮罩编辑 (Ctrl+Enter)' : '生成 (Ctrl+Enter)') : '请先配置 API'}
                   >
                     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
@@ -858,7 +930,7 @@ export default function InputBar() {
                     <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
                     </svg>
-                    生成图像
+                    {maskDraft ? '遮罩编辑' : '生成图像'}
                   </button>
                 </div>
               </div>

--- a/src/components/MaskEditorModal.tsx
+++ b/src/components/MaskEditorModal.tsx
@@ -1,0 +1,761 @@
+import { useEffect, useRef, useState } from 'react'
+import type { PointerEvent as ReactPointerEvent } from 'react'
+import { ensureImageCached, useStore } from '../store'
+import { canvasToBlob, loadImage } from '../lib/canvasImage'
+import { storeImage } from '../lib/db'
+import { prepareMaskTargetDataUrl, replaceMaskTargetImage } from '../lib/maskPreprocess'
+import { useCloseOnEscape } from '../hooks/useCloseOnEscape'
+import {
+  clampViewTransform,
+  clientPointToCanvasPoint,
+  getComfortableInitialTransform,
+  getPinchTransform,
+  type Point,
+  type ViewTransform,
+} from '../lib/viewportTransform'
+
+type Tool = 'brush' | 'eraser'
+
+interface CanvasSize {
+  width: number
+  height: number
+}
+
+interface PinchGesture {
+  startTransform: ViewTransform
+  startCentroid: Point
+  startDistance: number
+}
+
+const DEFAULT_VIEW_TRANSFORM: ViewTransform = { scale: 1, x: 0, y: 0 }
+
+function getCanvasPoint(canvas: HTMLCanvasElement, event: ReactPointerEvent<HTMLCanvasElement>): Point {
+  return clientPointToCanvasPoint(
+    canvas.getBoundingClientRect(),
+    { x: event.clientX, y: event.clientY },
+    { width: canvas.width, height: canvas.height },
+  )
+}
+
+function distance(a: Point, b: Point): number {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+function centroid(a: Point, b: Point): Point {
+  return {
+    x: (a.x + b.x) / 2,
+    y: (a.y + b.y) / 2,
+  }
+}
+
+function firstTwoPointers(points: Map<number, Point>): [Point, Point] | null {
+  const values = Array.from(points.values())
+  return values.length >= 2 ? [values[0], values[1]] : null
+}
+
+function fillWhiteMask(canvas: HTMLCanvasElement) {
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  if (!ctx) throw new Error('当前浏览器不支持 Canvas')
+  ctx.globalCompositeOperation = 'source-over'
+  ctx.clearRect(0, 0, canvas.width, canvas.height)
+  ctx.fillStyle = '#fff'
+  ctx.fillRect(0, 0, canvas.width, canvas.height)
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error ?? new Error('图片导出失败'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+export default function MaskEditorModal() {
+  const imageId = useStore((s) => s.maskEditorImageId)
+  const setMaskEditorImageId = useStore((s) => s.setMaskEditorImageId)
+  const maskDraft = useStore((s) => s.maskDraft)
+  const setMaskDraft = useStore((s) => s.setMaskDraft)
+  const showToast = useStore((s) => s.showToast)
+
+  const imageCanvasRef = useRef<HTMLCanvasElement>(null)
+  const previewCanvasRef = useRef<HTMLCanvasElement>(null)
+  const maskCanvasRef = useRef<HTMLCanvasElement>(null)
+  const stageRef = useRef<HTMLDivElement>(null)
+  const baseFrameRef = useRef<HTMLDivElement>(null)
+  const activePointerIdRef = useRef<number | null>(null)
+  const lastPointRef = useRef<Point | null>(null)
+  const pointerPositionsRef = useRef<Map<number, Point>>(new Map())
+  const pinchGestureRef = useRef<PinchGesture | null>(null)
+  const undoStackRef = useRef<ImageData[]>([])
+  const redoStackRef = useRef<ImageData[]>([])
+  const saveTokenRef = useRef(0)
+  const sessionIdRef = useRef(0)
+  const activeSessionIdRef = useRef(0)
+  const viewTransformRef = useRef<ViewTransform>(DEFAULT_VIEW_TRANSFORM)
+
+  const [sourceDataUrl, setSourceDataUrl] = useState('')
+  const [size, setSize] = useState<CanvasSize | null>(null)
+  const [tool, setTool] = useState<Tool>('brush')
+  const [brushSize, setBrushSize] = useState(64)
+  const [viewTransform, setViewTransform] = useState<ViewTransform>(DEFAULT_VIEW_TRANSFORM)
+  const [showBrushControls, setShowBrushControls] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [isSaving, setIsSaving] = useState(false)
+  const [historyState, setHistoryState] = useState({ undo: 0, redo: 0 })
+
+  const close = () => {
+    if (isSaving) return
+    setMaskEditorImageId(null)
+  }
+  useCloseOnEscape(Boolean(imageId), close)
+
+  function commitViewTransform(nextTransform: ViewTransform) {
+    const frame = baseFrameRef.current
+    const clamped = frame
+      ? clampViewTransform(nextTransform, { width: frame.clientWidth, height: frame.clientHeight })
+      : nextTransform
+    viewTransformRef.current = clamped
+    setViewTransform(clamped)
+  }
+
+  function resetViewTransform() {
+    const frame = baseFrameRef.current
+    const stage = stageRef.current
+    const isCompactLayout = window.matchMedia('(max-width: 1023px)').matches
+    if (!frame || !stage) {
+      commitViewTransform(DEFAULT_VIEW_TRANSFORM)
+      return
+    }
+
+    commitViewTransform(getComfortableInitialTransform(
+      { width: frame.clientWidth, height: frame.clientHeight },
+      { width: stage.clientWidth, height: stage.clientHeight },
+      isCompactLayout,
+    ))
+  }
+
+  function cancelActiveStroke() {
+    if (activePointerIdRef.current == null) return
+
+    const previous = undoStackRef.current.pop()
+    if (previous) restoreMask(previous)
+    activePointerIdRef.current = null
+    lastPointRef.current = null
+    syncHistoryState()
+  }
+
+  function beginPinchGesture() {
+    const pointers = firstTwoPointers(pointerPositionsRef.current)
+    const frame = baseFrameRef.current
+    if (!pointers || !frame) return
+
+    const rect = frame.getBoundingClientRect()
+    const startCentroid = centroid(pointers[0], pointers[1])
+    pinchGestureRef.current = {
+      startTransform: viewTransformRef.current,
+      startCentroid: {
+        x: startCentroid.x - rect.left,
+        y: startCentroid.y - rect.top,
+      },
+      startDistance: distance(pointers[0], pointers[1]),
+    }
+  }
+
+  function updatePinchGesture() {
+    const pointers = firstTwoPointers(pointerPositionsRef.current)
+    const gesture = pinchGestureRef.current
+    const frame = baseFrameRef.current
+    if (!pointers || !gesture || !frame) return
+
+    const rect = frame.getBoundingClientRect()
+    const nextCentroid = centroid(pointers[0], pointers[1])
+    commitViewTransform(getPinchTransform({
+      startTransform: gesture.startTransform,
+      startCentroid: gesture.startCentroid,
+      nextCentroid: {
+        x: nextCentroid.x - rect.left,
+        y: nextCentroid.y - rect.top,
+      },
+      startDistance: gesture.startDistance,
+      nextDistance: distance(pointers[0], pointers[1]),
+      viewportSize: { width: frame.clientWidth, height: frame.clientHeight },
+    }))
+  }
+
+  function syncHistoryState() {
+    setHistoryState({
+      undo: undoStackRef.current.length,
+      redo: redoStackRef.current.length,
+    })
+  }
+
+  function renderPreview() {
+    const maskCanvas = maskCanvasRef.current
+    const previewCanvas = previewCanvasRef.current
+    if (!maskCanvas || !previewCanvas) return
+
+    const maskCtx = maskCanvas.getContext('2d', { willReadFrequently: true })
+    const previewCtx = previewCanvas.getContext('2d')
+    if (!maskCtx || !previewCtx) return
+
+    const maskPixels = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height)
+    const overlay = previewCtx.createImageData(previewCanvas.width, previewCanvas.height)
+
+    for (let i = 0; i < maskPixels.data.length; i += 4) {
+      const editStrength = 255 - maskPixels.data[i + 3]
+      overlay.data[i] = 255
+      overlay.data[i + 1] = 112
+      overlay.data[i + 2] = 32
+      overlay.data[i + 3] = Math.round(editStrength * 0.58)
+    }
+
+    previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height)
+    previewCtx.putImageData(overlay, 0, 0)
+  }
+
+  function pushUndoSnapshot() {
+    const canvas = maskCanvasRef.current
+    const ctx = canvas?.getContext('2d', { willReadFrequently: true })
+    if (!canvas || !ctx) return
+
+    undoStackRef.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height))
+    if (undoStackRef.current.length > 40) undoStackRef.current.shift()
+    redoStackRef.current = []
+    syncHistoryState()
+  }
+
+  function restoreMask(imageData: ImageData) {
+    const canvas = maskCanvasRef.current
+    const ctx = canvas?.getContext('2d', { willReadFrequently: true })
+    if (!canvas || !ctx) return
+
+    ctx.putImageData(imageData, 0, 0)
+    renderPreview()
+  }
+
+  function drawAt(point: Point, nextTool = tool) {
+    const canvas = maskCanvasRef.current
+    const ctx = canvas?.getContext('2d')
+    if (!canvas || !ctx) return
+
+    ctx.save()
+    ctx.globalCompositeOperation = nextTool === 'brush' ? 'destination-out' : 'source-over'
+    ctx.fillStyle = '#fff'
+    ctx.beginPath()
+    ctx.arc(point.x, point.y, brushSize / 2, 0, Math.PI * 2)
+    ctx.fill()
+    ctx.restore()
+    renderPreview()
+  }
+
+  function drawStroke(from: Point, to: Point, nextTool = tool) {
+    const canvas = maskCanvasRef.current
+    const ctx = canvas?.getContext('2d')
+    if (!canvas || !ctx) return
+
+    ctx.save()
+    ctx.globalCompositeOperation = nextTool === 'brush' ? 'destination-out' : 'source-over'
+    ctx.strokeStyle = '#fff'
+    ctx.lineWidth = brushSize
+    ctx.lineCap = 'round'
+    ctx.lineJoin = 'round'
+    ctx.beginPath()
+    ctx.moveTo(from.x, from.y)
+    ctx.lineTo(to.x, to.y)
+    ctx.stroke()
+    ctx.restore()
+    renderPreview()
+  }
+
+  useEffect(() => {
+    if (!imageId) {
+      activeSessionIdRef.current = 0
+      return
+    }
+
+    const nextSessionId = sessionIdRef.current + 1
+    sessionIdRef.current = nextSessionId
+    activeSessionIdRef.current = nextSessionId
+
+    return () => {
+      if (activeSessionIdRef.current === nextSessionId) {
+        activeSessionIdRef.current = 0
+      }
+    }
+  }, [imageId])
+
+  useEffect(() => {
+    if (!imageId) {
+      setSourceDataUrl('')
+      setSize(null)
+      setShowBrushControls(false)
+      setIsLoading(false)
+      pointerPositionsRef.current.clear()
+      pinchGestureRef.current = null
+      viewTransformRef.current = DEFAULT_VIEW_TRANSFORM
+      setViewTransform(DEFAULT_VIEW_TRANSFORM)
+      undoStackRef.current = []
+      redoStackRef.current = []
+      syncHistoryState()
+      return
+    }
+
+    const targetImageId = imageId
+    let cancelled = false
+    setIsLoading(true)
+    setSourceDataUrl('')
+    setSize(null)
+    undoStackRef.current = []
+    redoStackRef.current = []
+    syncHistoryState()
+
+    async function loadCanvases() {
+      try {
+        const dataUrl = await ensureImageCached(targetImageId)
+        if (cancelled) return
+        if (!dataUrl) {
+          showToast('图片已不存在，无法编辑遮罩', 'error')
+          setMaskEditorImageId(null)
+          return
+        }
+
+        const preparedTarget = await prepareMaskTargetDataUrl(dataUrl)
+        const image = await loadImage(preparedTarget.dataUrl)
+        if (cancelled) return
+
+        const nextSize = { width: preparedTarget.width, height: preparedTarget.height }
+        const imageCanvas = imageCanvasRef.current
+        const previewCanvas = previewCanvasRef.current
+        const maskCanvas = maskCanvasRef.current
+        if (!imageCanvas || !previewCanvas || !maskCanvas) return
+
+        for (const canvas of [imageCanvas, previewCanvas, maskCanvas]) {
+          canvas.width = nextSize.width
+          canvas.height = nextSize.height
+        }
+
+        const imageCtx = imageCanvas.getContext('2d')
+        if (!imageCtx) throw new Error('当前浏览器不支持 Canvas')
+        imageCtx.clearRect(0, 0, imageCanvas.width, imageCanvas.height)
+        imageCtx.drawImage(image, 0, 0)
+
+        fillWhiteMask(maskCanvas)
+
+        if (maskDraft?.targetImageId === targetImageId) {
+          try {
+            const draftImage = await loadImage(maskDraft.maskDataUrl)
+            if (cancelled) return
+            if (draftImage.naturalWidth !== nextSize.width || draftImage.naturalHeight !== nextSize.height) {
+              throw new Error('遮罩尺寸与当前图片不一致')
+            }
+            const maskCtx = maskCanvas.getContext('2d', { willReadFrequently: true })
+            if (!maskCtx) throw new Error('当前浏览器不支持 Canvas')
+            maskCtx.clearRect(0, 0, maskCanvas.width, maskCanvas.height)
+            maskCtx.drawImage(draftImage, 0, 0)
+          } catch (err) {
+            fillWhiteMask(maskCanvas)
+            showToast(
+              `遮罩草稿加载失败，已重置为空白遮罩：${err instanceof Error ? err.message : String(err)}`,
+              'error',
+            )
+          }
+        }
+
+        renderPreview()
+        setSourceDataUrl(preparedTarget.dataUrl)
+        setSize(nextSize)
+        if (preparedTarget.wasResized) {
+          showToast(
+            `已为遮罩编辑优化图片尺寸：${preparedTarget.originalWidth}×${preparedTarget.originalHeight} → ${preparedTarget.width}×${preparedTarget.height}`,
+            'info',
+          )
+        }
+        requestAnimationFrame(() => resetViewTransform())
+      } catch (err) {
+        if (!cancelled) {
+          showToast(err instanceof Error ? err.message : String(err), 'error')
+          setMaskEditorImageId(null)
+        }
+      } finally {
+        if (!cancelled) setIsLoading(false)
+      }
+    }
+
+    void loadCanvases()
+
+    return () => {
+      cancelled = true
+      activePointerIdRef.current = null
+      lastPointRef.current = null
+      pointerPositionsRef.current.clear()
+      pinchGestureRef.current = null
+    }
+  }, [imageId, maskDraft, setMaskEditorImageId, showToast])
+
+  useEffect(() => {
+    const frame = baseFrameRef.current
+    if (!frame || typeof ResizeObserver === 'undefined') return
+
+    const observer = new ResizeObserver(() => {
+      commitViewTransform(viewTransformRef.current)
+    })
+    observer.observe(frame)
+    return () => observer.disconnect()
+  }, [size])
+
+  if (!imageId) return null
+
+  const isReady = Boolean(sourceDataUrl && size && !isLoading)
+  const canUndo = historyState.undo > 0 && isReady && !isSaving
+  const canRedo = historyState.redo > 0 && isReady && !isSaving
+  const isZoomed = viewTransform.scale > 1.01 || Math.abs(viewTransform.x) > 1 || Math.abs(viewTransform.y) > 1
+
+  const handlePointerDown = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (!isReady || isSaving || (event.pointerType !== 'touch' && event.button !== 0)) return
+    event.preventDefault()
+    const canvas = event.currentTarget
+    pointerPositionsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+    if (!canvas.hasPointerCapture(event.pointerId)) {
+      canvas.setPointerCapture(event.pointerId)
+    }
+
+    if (pointerPositionsRef.current.size >= 2) {
+      cancelActiveStroke()
+      beginPinchGesture()
+      return
+    }
+
+    activePointerIdRef.current = event.pointerId
+    pushUndoSnapshot()
+    const point = getCanvasPoint(canvas, event)
+    lastPointRef.current = point
+    drawAt(point)
+  }
+
+  const handlePointerMove = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (pointerPositionsRef.current.has(event.pointerId)) {
+      pointerPositionsRef.current.set(event.pointerId, { x: event.clientX, y: event.clientY })
+    }
+    if (pinchGestureRef.current && pointerPositionsRef.current.size >= 2) {
+      event.preventDefault()
+      updatePinchGesture()
+      return
+    }
+    if (activePointerIdRef.current !== event.pointerId || !lastPointRef.current || !isReady || isSaving) return
+    event.preventDefault()
+    const point = getCanvasPoint(event.currentTarget, event)
+    drawStroke(lastPointRef.current, point)
+    lastPointRef.current = point
+  }
+
+  const finishStroke = (event: ReactPointerEvent<HTMLCanvasElement>) => {
+    if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      event.currentTarget.releasePointerCapture(event.pointerId)
+    }
+    pointerPositionsRef.current.delete(event.pointerId)
+
+    if (pinchGestureRef.current) {
+      if (pointerPositionsRef.current.size >= 2) beginPinchGesture()
+      else pinchGestureRef.current = null
+    }
+
+    if (activePointerIdRef.current === event.pointerId) {
+      activePointerIdRef.current = null
+      lastPointRef.current = null
+    }
+  }
+
+  const handleUndo = () => {
+    const canvas = maskCanvasRef.current
+    const ctx = canvas?.getContext('2d', { willReadFrequently: true })
+    const previous = undoStackRef.current.pop()
+    if (!canvas || !ctx || !previous) return
+
+    redoStackRef.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height))
+    restoreMask(previous)
+    syncHistoryState()
+  }
+
+  const handleRedo = () => {
+    const canvas = maskCanvasRef.current
+    const ctx = canvas?.getContext('2d', { willReadFrequently: true })
+    const next = redoStackRef.current.pop()
+    if (!canvas || !ctx || !next) return
+
+    undoStackRef.current.push(ctx.getImageData(0, 0, canvas.width, canvas.height))
+    restoreMask(next)
+    syncHistoryState()
+  }
+
+  const handleClear = () => {
+    const canvas = maskCanvasRef.current
+    if (!canvas || !isReady || isSaving) return
+
+    pushUndoSnapshot()
+    fillWhiteMask(canvas)
+    renderPreview()
+  }
+
+  const handleSave = async () => {
+    const canvas = maskCanvasRef.current
+    const savingSessionId = activeSessionIdRef.current
+    if (!canvas || !sourceDataUrl || !imageId || !isReady || isSaving || !savingSessionId) return
+
+    const token = ++saveTokenRef.current
+    const savingImageId = imageId
+    try {
+      setIsSaving(true)
+      const blob = await canvasToBlob(canvas, 'image/png')
+      const maskDataUrl = await blobToDataUrl(blob)
+      const workingTargetId = await storeImage(sourceDataUrl, 'upload')
+      if (
+        saveTokenRef.current !== token ||
+        activeSessionIdRef.current !== savingSessionId ||
+        useStore.getState().maskEditorImageId !== savingImageId
+      ) return
+
+      const latestStore = useStore.getState()
+      latestStore.setInputImages(
+        replaceMaskTargetImage(latestStore.inputImages, savingImageId, {
+          id: workingTargetId,
+          dataUrl: sourceDataUrl,
+        }),
+      )
+      setMaskDraft({
+        targetImageId: workingTargetId,
+        maskDataUrl,
+        updatedAt: Date.now(),
+      })
+      setMaskEditorImageId(null)
+      showToast('遮罩已保存', 'success')
+    } catch (err) {
+      if (
+        saveTokenRef.current !== token ||
+        activeSessionIdRef.current !== savingSessionId ||
+        useStore.getState().maskEditorImageId !== savingImageId
+      ) return
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+    } finally {
+      if (saveTokenRef.current === token) setIsSaving(false)
+    }
+  }
+
+  const toolButtonClass = (active: boolean) =>
+    `flex-1 rounded-xl px-3 py-2 text-sm font-medium transition ${
+      active
+        ? 'bg-orange-500 text-white shadow-sm shadow-orange-500/20'
+        : 'bg-white/60 text-gray-600 hover:bg-white dark:bg-white/[0.04] dark:text-gray-300 dark:hover:bg-white/[0.08]'
+    }`
+
+  const actionButtonClass =
+    'rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2 text-sm text-gray-600 transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-45 dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-300 dark:hover:bg-white/[0.08]'
+
+  const compactButtonClass = (active = false) =>
+    `h-9 rounded-xl px-2 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-45 ${
+      active
+        ? 'bg-orange-500 text-white shadow-sm shadow-orange-500/20'
+        : 'border border-gray-200/70 bg-white/70 text-gray-600 hover:bg-white dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-300 dark:hover:bg-white/[0.08]'
+    }`
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-end justify-center sm:items-center sm:p-4">
+      <div className="absolute inset-0 bg-black/30 backdrop-blur-md animate-overlay-in" onClick={close} />
+      <div
+        className="relative z-10 flex h-[100dvh] w-full flex-col overflow-hidden bg-white/95 shadow-2xl ring-1 ring-black/5 animate-modal-in dark:bg-gray-900/95 dark:ring-white/10 sm:h-[92vh] sm:max-w-6xl sm:rounded-3xl sm:border sm:border-white/50 dark:sm:border-white/[0.08]"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mask-editor-title"
+      >
+        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-gray-100 px-4 py-3 dark:border-white/[0.08] sm:px-5">
+          <div className="min-w-0">
+            <h3 id="mask-editor-title" className="text-base font-semibold text-gray-800 dark:text-gray-100">编辑遮罩</h3>
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              <span className="sm:hidden">单指涂抹，双指缩放/平移。</span>
+              <span className="hidden sm:inline">橙色区域将被编辑；未涂抹区域保持白色保护。</span>
+            </p>
+          </div>
+          <button
+            onClick={close}
+            className="rounded-full p-1 text-gray-400 transition hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-white/[0.06] dark:hover:text-gray-200"
+            aria-label="关闭"
+          >
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex min-h-0 flex-1 flex-col gap-2 p-2 sm:gap-4 sm:p-4 lg:flex-row lg:p-5">
+          <div ref={stageRef} className="relative flex min-h-0 flex-1 items-center justify-center overflow-hidden rounded-2xl border border-gray-200/70 bg-[radial-gradient(circle_at_20%_20%,rgba(249,115,22,0.12),transparent_26%),linear-gradient(135deg,rgba(15,23,42,0.06),rgba(255,255,255,0.72))] p-2 dark:border-white/[0.08] dark:bg-[radial-gradient(circle_at_20%_20%,rgba(249,115,22,0.16),transparent_28%),linear-gradient(135deg,rgba(255,255,255,0.05),rgba(0,0,0,0.28))] sm:rounded-3xl sm:p-3">
+            {isLoading && (
+              <div className="absolute inset-0 z-20 flex items-center justify-center bg-white/50 text-sm text-gray-500 backdrop-blur-sm dark:bg-gray-900/50 dark:text-gray-300">
+                正在载入图片...
+              </div>
+            )}
+            <div className="absolute left-3 top-3 z-10 rounded-full bg-black/45 px-2.5 py-1 text-[11px] text-white backdrop-blur-sm lg:hidden">
+              {viewTransform.scale.toFixed(1)}x · 双指缩放
+            </div>
+            <div
+              ref={baseFrameRef}
+              className="relative max-h-full max-w-full rounded-2xl bg-gray-950/5 shadow-[0_20px_60px_rgba(15,23,42,0.18)] ring-1 ring-black/10 touch-none dark:bg-black/30 dark:ring-white/10"
+              style={{
+                aspectRatio: size ? `${size.width} / ${size.height}` : '1 / 1',
+                width: size ? 'min(100%, calc((100dvh - 10rem) * var(--mask-aspect)))' : 'min(100%, 520px)',
+                maxHeight: '100%',
+                ['--mask-aspect' as string]: size ? String(size.width / size.height) : '1',
+              }}
+            >
+              <div
+                className="absolute inset-0 will-change-transform"
+                style={{
+                  transform: `matrix(${viewTransform.scale}, 0, 0, ${viewTransform.scale}, ${viewTransform.x}, ${viewTransform.y})`,
+                  transformOrigin: '0 0',
+                }}
+              >
+                <canvas ref={imageCanvasRef} className="absolute inset-0 h-full w-full" />
+                <canvas ref={previewCanvasRef} className="absolute inset-0 h-full w-full pointer-events-none" />
+                <canvas
+                  ref={maskCanvasRef}
+                  className="absolute inset-0 h-full w-full touch-none select-none opacity-0"
+                  onPointerDown={handlePointerDown}
+                  onPointerMove={handlePointerMove}
+                  onPointerUp={finishStroke}
+                  onPointerCancel={finishStroke}
+                  onLostPointerCapture={finishStroke}
+                />
+              </div>
+            </div>
+          </div>
+
+          <aside className="hidden w-full rounded-3xl border border-gray-200/70 bg-white/70 p-4 dark:border-white/[0.08] dark:bg-white/[0.03] lg:block lg:w-72">
+            <div className="space-y-5">
+              <section>
+                <div className="mb-2 text-xs font-medium text-gray-400 dark:text-gray-500">工具</div>
+                <div className="flex rounded-2xl bg-gray-100/80 p-1 dark:bg-black/20">
+                  <button className={toolButtonClass(tool === 'brush')} onClick={() => setTool('brush')} disabled={!isReady || isSaving}>
+                    画笔
+                  </button>
+                  <button className={toolButtonClass(tool === 'eraser')} onClick={() => setTool('eraser')} disabled={!isReady || isSaving}>
+                    橡皮
+                  </button>
+                </div>
+                <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                  画笔创建透明编辑区，橡皮恢复白色保护区。
+                </p>
+              </section>
+
+              <section>
+                <div className="mb-2 flex items-center justify-between text-xs font-medium text-gray-400 dark:text-gray-500">
+                  <span>笔刷大小</span>
+                  <span className="font-mono text-gray-500 dark:text-gray-300">{brushSize}px</span>
+                </div>
+                <input
+                  type="range"
+                  min={8}
+                  max={220}
+                  value={brushSize}
+                  onChange={(e) => setBrushSize(Number(e.target.value))}
+                  className="w-full accent-orange-500"
+                  disabled={!isReady || isSaving}
+                />
+              </section>
+
+              <section>
+                <div className="mb-2 text-xs font-medium text-gray-400 dark:text-gray-500">历史</div>
+                <div className="grid grid-cols-3 gap-2">
+                  <button onClick={handleUndo} disabled={!canUndo} className={actionButtonClass}>
+                    撤销
+                  </button>
+                  <button onClick={handleRedo} disabled={!canRedo} className={actionButtonClass}>
+                    重做
+                  </button>
+                  <button onClick={handleClear} disabled={!isReady || isSaving} className={actionButtonClass}>
+                    清空
+                  </button>
+                </div>
+              </section>
+
+              <section>
+                <div className="mb-2 text-xs font-medium text-gray-400 dark:text-gray-500">视图</div>
+                <button onClick={resetViewTransform} disabled={!isReady || isSaving || !isZoomed} className={actionButtonClass}>
+                  重置视图 · {viewTransform.scale.toFixed(1)}x
+                </button>
+                <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+                  移动端可双指缩放/平移，单指继续绘制遮罩。
+                </p>
+              </section>
+
+              <section className="rounded-2xl bg-orange-50/80 p-3 text-xs leading-relaxed text-orange-700 dark:bg-orange-500/10 dark:text-orange-200">
+                保存后会把当前图片加入参考图，并在提交时作为遮罩主图使用。
+              </section>
+            </div>
+          </aside>
+        </div>
+
+        <div className="shrink-0 border-t border-gray-100 px-3 py-2 dark:border-white/[0.08] sm:px-5 sm:py-3">
+          <div className="lg:hidden">
+            <div className="flex items-center gap-1.5 overflow-x-auto pb-1">
+              <button className={`${compactButtonClass(tool === 'brush')} shrink-0`} onClick={() => setTool('brush')} disabled={!isReady || isSaving} aria-pressed={tool === 'brush'}>
+                画笔
+              </button>
+              <button className={`${compactButtonClass(tool === 'eraser')} shrink-0`} onClick={() => setTool('eraser')} disabled={!isReady || isSaving} aria-pressed={tool === 'eraser'}>
+                橡皮
+              </button>
+              <button className={`${compactButtonClass(showBrushControls)} shrink-0`} onClick={() => setShowBrushControls((v) => !v)} disabled={!isReady || isSaving}>
+                {brushSize}px
+              </button>
+              <button onClick={handleUndo} disabled={!canUndo} className={`${compactButtonClass()} shrink-0`}>
+                撤销
+              </button>
+              <button onClick={handleRedo} disabled={!canRedo} className={`${compactButtonClass()} shrink-0`}>
+                重做
+              </button>
+              <button onClick={handleClear} disabled={!isReady || isSaving} className={`${compactButtonClass()} shrink-0`}>
+                清空
+              </button>
+              <button onClick={resetViewTransform} disabled={!isReady || isSaving || !isZoomed} className={`${compactButtonClass()} shrink-0`}>
+                重置
+              </button>
+            </div>
+            {showBrushControls && (
+              <div className="mt-2 rounded-2xl border border-gray-200/70 bg-white/75 px-3 py-2 dark:border-white/[0.08] dark:bg-white/[0.04]">
+                <div className="mb-1 flex items-center justify-between text-xs text-gray-400 dark:text-gray-500">
+                  <span>笔刷大小</span>
+                  <span className="font-mono text-gray-600 dark:text-gray-300">{brushSize}px</span>
+                </div>
+                <input
+                  type="range"
+                  min={8}
+                  max={220}
+                  value={brushSize}
+                  onChange={(e) => setBrushSize(Number(e.target.value))}
+                  className="w-full accent-orange-500"
+                  disabled={!isReady || isSaving}
+                />
+              </div>
+            )}
+          </div>
+
+          <div className="mt-2 grid grid-cols-[1fr_1.5fr] gap-2 sm:flex sm:flex-row sm:justify-end lg:mt-0">
+            <button
+              onClick={close}
+              disabled={isSaving}
+              className="rounded-xl border border-gray-200/70 bg-white/70 px-4 py-2 text-sm text-gray-600 transition hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-45 dark:border-white/[0.08] dark:bg-white/[0.04] dark:text-gray-300 dark:hover:bg-white/[0.08]"
+            >
+              取消
+            </button>
+            <button
+              onClick={handleSave}
+              disabled={!isReady || isSaving}
+              className="rounded-xl bg-orange-500 px-4 py-2 text-sm font-medium text-white shadow-sm shadow-orange-500/20 transition hover:bg-orange-600 disabled:cursor-not-allowed disabled:bg-gray-300 disabled:shadow-none dark:disabled:bg-white/[0.08]"
+            >
+              {isSaving ? '保存中...' : '保存遮罩'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -284,6 +284,11 @@ export default function TaskCard({
                   {task.outputImages.length}
                 </span>
               )}
+              {task.maskImageId && (
+                <span className="absolute bottom-1 left-1 rounded bg-orange-500/90 px-1.5 py-0.5 text-xs font-medium text-white shadow-sm">
+                  Mask
+                </span>
+              )}
             </>
           )}
           {task.status === 'done' && !thumbSrc && (

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { AppSettings, ImageApiResponse, ResponsesApiResponse, TaskParams } from '../types'
+import { dataUrlToBlob, imageDataUrlToPngBlob, maskDataUrlToPngBlob } from './canvasImage'
 import { buildApiUrl, readClientDevProxyConfig } from './devProxy'
 
 const MIME_MAP: Record<string, string> = {
@@ -109,6 +110,8 @@ export interface CallApiOptions {
   params: TaskParams
   /** 输入图片的 data URL 列表 */
   inputImageDataUrls: string[]
+  /** 与第一张输入图片同尺寸的 PNG 遮罩；透明区域会被编辑 */
+  maskDataUrl?: string
 }
 
 export interface CallApiResult {
@@ -179,6 +182,10 @@ function mergeActualParams(...sources: Array<Partial<TaskParams>>): Partial<Task
 }
 
 export async function callImageApi(opts: CallApiOptions): Promise<CallApiResult> {
+  if (opts.maskDataUrl && opts.settings.apiMode === 'responses') {
+    throw new Error('遮罩编辑当前仅支持 Images API，请在设置中切换 API 模式')
+  }
+
   return opts.settings.apiMode === 'responses'
     ? callResponsesImageApi(opts)
     : callImagesApi(opts)
@@ -225,7 +232,7 @@ async function callImagesApiConcurrent(opts: CallApiOptions, n: number): Promise
 }
 
 async function callImagesApiSingle(opts: CallApiOptions): Promise<CallApiResult> {
-  const { settings, prompt: originalPrompt, params, inputImageDataUrls } = opts
+  const { settings, prompt: originalPrompt, params, inputImageDataUrls, maskDataUrl } = opts
   const prompt = settings.codexCli
     ? `Use the following text as the complete prompt. Do not rewrite it:\n${originalPrompt}`
     : originalPrompt
@@ -258,10 +265,14 @@ async function callImagesApiSingle(opts: CallApiOptions): Promise<CallApiResult>
 
       for (let i = 0; i < inputImageDataUrls.length; i++) {
         const dataUrl = inputImageDataUrls[i]
-        const resp = await fetch(dataUrl)
-        const blob = await resp.blob()
+        const blob = maskDataUrl && i === 0
+          ? await imageDataUrlToPngBlob(dataUrl)
+          : await dataUrlToBlob(dataUrl)
         const ext = blob.type.split('/')[1] || 'png'
         formData.append('image[]', blob, `input-${i + 1}.${ext}`)
+      }
+      if (maskDataUrl) {
+        formData.append('mask', await maskDataUrlToPngBlob(maskDataUrl), 'mask.png')
       }
 
       response = await fetch(buildApiUrl(settings.baseUrl, 'images/edits', proxyConfig), {

--- a/src/lib/canvasImage.ts
+++ b/src/lib/canvasImage.ts
@@ -1,0 +1,112 @@
+import { assertUsableMaskCoverage, classifyMaskAlpha, type MaskCoverage } from './mask'
+
+export interface ImageDimensions {
+  width: number
+  height: number
+}
+
+export async function loadImage(dataUrl: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image()
+    image.onload = () => resolve(image)
+    image.onerror = () => reject(new Error('图片加载失败'))
+    image.src = dataUrl
+  })
+}
+
+export async function getImageDimensions(dataUrl: string): Promise<ImageDimensions> {
+  const image = await loadImage(dataUrl)
+  return { width: image.naturalWidth, height: image.naturalHeight }
+}
+
+export async function dataUrlToBlob(dataUrl: string, fallbackType = 'image/png'): Promise<Blob> {
+  const response = await fetch(dataUrl)
+  const blob = await response.blob()
+  return blob.type ? blob : new Blob([await blob.arrayBuffer()], { type: fallbackType })
+}
+
+export async function canvasToBlob(canvas: HTMLCanvasElement, type = 'image/png', quality?: number): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (!blob) reject(new Error('图片导出失败'))
+      else resolve(blob)
+    }, type, quality)
+  })
+}
+
+export async function imageDataUrlToPngBlob(dataUrl: string): Promise<Blob> {
+  const image = await loadImage(dataUrl)
+  const canvas = document.createElement('canvas')
+  canvas.width = image.naturalWidth
+  canvas.height = image.naturalHeight
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('当前浏览器不支持 Canvas')
+  ctx.drawImage(image, 0, 0)
+  return canvasToBlob(canvas, 'image/png')
+}
+
+export async function maskDataUrlToPngBlob(maskDataUrl: string): Promise<Blob> {
+  const blob = await dataUrlToBlob(maskDataUrl, 'image/png')
+  if (blob.type !== 'image/png') {
+    return imageDataUrlToPngBlob(maskDataUrl)
+  }
+  return blob
+}
+
+export async function validateMaskMatchesImage(maskDataUrl: string, imageDataUrl: string): Promise<MaskCoverage> {
+  const [maskImage, sourceImage] = await Promise.all([loadImage(maskDataUrl), loadImage(imageDataUrl)])
+  if (maskImage.naturalWidth !== sourceImage.naturalWidth || maskImage.naturalHeight !== sourceImage.naturalHeight) {
+    throw new Error('遮罩尺寸与遮罩主图不一致，请重新绘制遮罩')
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = maskImage.naturalWidth
+  canvas.height = maskImage.naturalHeight
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  if (!ctx) throw new Error('当前浏览器不支持 Canvas')
+  ctx.drawImage(maskImage, 0, 0)
+  const coverage = classifyMaskAlpha(ctx.getImageData(0, 0, canvas.width, canvas.height))
+  assertUsableMaskCoverage(coverage)
+  return coverage
+}
+
+export async function createMaskPreviewDataUrl(imageDataUrl: string, maskDataUrl: string): Promise<string> {
+  const [image, mask] = await Promise.all([loadImage(imageDataUrl), loadImage(maskDataUrl)])
+  if (image.naturalWidth !== mask.naturalWidth || image.naturalHeight !== mask.naturalHeight) {
+    throw new Error('遮罩尺寸与遮罩主图不一致，请重新绘制遮罩')
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = image.naturalWidth
+  canvas.height = image.naturalHeight
+  const ctx = canvas.getContext('2d', { willReadFrequently: true })
+  if (!ctx) throw new Error('当前浏览器不支持 Canvas')
+
+  ctx.drawImage(image, 0, 0)
+
+  const maskCanvas = document.createElement('canvas')
+  maskCanvas.width = mask.naturalWidth
+  maskCanvas.height = mask.naturalHeight
+  const maskCtx = maskCanvas.getContext('2d', { willReadFrequently: true })
+  if (!maskCtx) throw new Error('当前浏览器不支持 Canvas')
+  maskCtx.drawImage(mask, 0, 0)
+  const maskPixels = maskCtx.getImageData(0, 0, maskCanvas.width, maskCanvas.height)
+
+  const overlay = ctx.createImageData(canvas.width, canvas.height)
+  for (let i = 0; i < maskPixels.data.length; i += 4) {
+    const editStrength = 255 - maskPixels.data[i + 3]
+    overlay.data[i] = 255
+    overlay.data[i + 1] = 96
+    overlay.data[i + 2] = 32
+    overlay.data[i + 3] = Math.round(editStrength * 0.55)
+  }
+
+  const overlayCanvas = document.createElement('canvas')
+  overlayCanvas.width = canvas.width
+  overlayCanvas.height = canvas.height
+  const overlayCtx = overlayCanvas.getContext('2d')
+  if (!overlayCtx) throw new Error('当前浏览器不支持 Canvas')
+  overlayCtx.putImageData(overlay, 0, 0)
+  ctx.drawImage(overlayCanvas, 0, 0)
+  return canvas.toDataURL('image/png')
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -112,7 +112,7 @@ function hashDataUrlFallback(dataUrl: string): string {
  * 存储图片，若已存在（按 hash 去重）则跳过。
  * 返回 image id。
  */
-export async function storeImage(dataUrl: string, source: 'upload' | 'generated' = 'upload'): Promise<string> {
+export async function storeImage(dataUrl: string, source: 'upload' | 'mask' | 'generated' = 'upload'): Promise<string> {
   const id = await hashDataUrl(dataUrl)
   const existing = await getImage(id)
   if (!existing) {

--- a/src/lib/mask.test.ts
+++ b/src/lib/mask.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertUsableMaskCoverage,
+  classifyMaskAlpha,
+  orderInputImagesForMask,
+  validateMaskTarget,
+} from './mask'
+import type { InputImage } from '../types'
+
+function img(id: string): InputImage {
+  return { id, dataUrl: `data:image/png;base64,${id}` }
+}
+
+function alphaImageData(alphaValues: number[]): ImageData {
+  const data = new Uint8ClampedArray(alphaValues.length * 4)
+  alphaValues.forEach((alpha, idx) => {
+    data[idx * 4] = 255
+    data[idx * 4 + 1] = 255
+    data[idx * 4 + 2] = 255
+    data[idx * 4 + 3] = alpha
+  })
+  return { data, width: alphaValues.length, height: 1, colorSpace: 'srgb' } as ImageData
+}
+
+describe('orderInputImagesForMask', () => {
+  it('moves the mask target to the first request image without dropping references', () => {
+    const ordered = orderInputImagesForMask([img('a'), img('b'), img('c')], 'b')
+    expect(ordered.map((i) => i.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('preserves order when the mask target is already first', () => {
+    const ordered = orderInputImagesForMask([img('a'), img('b')], 'a')
+    expect(ordered.map((i) => i.id)).toEqual(['a', 'b'])
+  })
+
+  it('throws when the target image is not present', () => {
+    expect(() => orderInputImagesForMask([img('a')], 'missing')).toThrow('遮罩主图已不存在')
+  })
+})
+
+describe('validateMaskTarget', () => {
+  it('returns the target image when present', () => {
+    expect(validateMaskTarget([img('a'), img('b')], 'b').id).toBe('b')
+  })
+
+  it('throws for an empty target id', () => {
+    expect(() => validateMaskTarget([img('a')], '')).toThrow('遮罩主图已不存在')
+  })
+})
+
+describe('classifyMaskAlpha', () => {
+  it('classifies no transparent pixels as empty', () => {
+    expect(classifyMaskAlpha(alphaImageData([255, 255, 255]))).toBe('empty')
+  })
+
+  it('classifies all transparent pixels as full', () => {
+    expect(classifyMaskAlpha(alphaImageData([0, 0, 0]))).toBe('full')
+  })
+
+  it('classifies mixed alpha values as partial', () => {
+    expect(classifyMaskAlpha(alphaImageData([255, 0, 128]))).toBe('partial')
+  })
+})
+
+describe('assertUsableMaskCoverage', () => {
+  it('rejects masks with no edit area', () => {
+    expect(() => assertUsableMaskCoverage('empty')).toThrow('请先涂抹需要编辑的区域')
+  })
+
+  it('allows partial masks', () => {
+    expect(() => assertUsableMaskCoverage('partial')).not.toThrow()
+  })
+
+  it('allows full masks so the UI can confirm before submit', () => {
+    expect(() => assertUsableMaskCoverage('full')).not.toThrow()
+  })
+})

--- a/src/lib/mask.ts
+++ b/src/lib/mask.ts
@@ -1,0 +1,35 @@
+import type { InputImage } from '../types'
+
+export type MaskCoverage = 'empty' | 'partial' | 'full'
+
+export function validateMaskTarget(inputImages: InputImage[], targetImageId: string): InputImage {
+  const target = inputImages.find((img) => img.id === targetImageId)
+  if (!target) throw new Error('遮罩主图已不存在，请重新选择遮罩区域')
+  return target
+}
+
+export function orderInputImagesForMask(inputImages: InputImage[], targetImageId: string): InputImage[] {
+  const target = validateMaskTarget(inputImages, targetImageId)
+  return [target, ...inputImages.filter((img) => img.id !== targetImageId)]
+}
+
+export function classifyMaskAlpha(imageData: Pick<ImageData, 'data'>): MaskCoverage {
+  let edited = 0
+  let fullyTransparent = 0
+  const total = imageData.data.length / 4
+
+  for (let i = 3; i < imageData.data.length; i += 4) {
+    if (imageData.data[i] < 255) edited++
+    if (imageData.data[i] === 0) fullyTransparent++
+  }
+
+  if (edited === 0) return 'empty'
+  if (fullyTransparent === total) return 'full'
+  return 'partial'
+}
+
+export function assertUsableMaskCoverage(coverage: MaskCoverage): void {
+  if (coverage === 'empty') {
+    throw new Error('请先涂抹需要编辑的区域')
+  }
+}

--- a/src/lib/maskPreprocess.test.ts
+++ b/src/lib/maskPreprocess.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { calculateMaskWorkingSize, replaceMaskTargetImage } from './maskPreprocess'
+import type { InputImage } from '../types'
+
+function image(id: string): InputImage {
+  return { id, dataUrl: `data:image/png;base64,${id}` }
+}
+
+describe('calculateMaskWorkingSize', () => {
+  it('keeps images at or below the mask working edge unchanged', () => {
+    expect(calculateMaskWorkingSize(1080, 1920)).toEqual({
+      width: 1080,
+      height: 1920,
+      scale: 1,
+      wasResized: false,
+    })
+  })
+
+  it('scales oversized portrait images proportionally to the mask working edge', () => {
+    expect(calculateMaskWorkingSize(3024, 4032)).toEqual({
+      width: 1440,
+      height: 1920,
+      scale: 1920 / 4032,
+      wasResized: true,
+    })
+  })
+
+  it('rounds resized dimensions down to multiples of 16', () => {
+    expect(calculateMaskWorkingSize(5000, 3333)).toEqual({
+      width: 1920,
+      height: 1264,
+      scale: 1920 / 5000,
+      wasResized: true,
+    })
+  })
+})
+
+describe('replaceMaskTargetImage', () => {
+  it('replaces the selected mask target with the prepared working image', () => {
+    expect(replaceMaskTargetImage([image('original'), image('ref')], 'original', image('working'))).toEqual([
+      image('working'),
+      image('ref'),
+    ])
+  })
+
+  it('deduplicates when the prepared working image is already present', () => {
+    expect(replaceMaskTargetImage([image('original'), image('working'), image('ref')], 'original', image('working'))).toEqual([
+      image('working'),
+      image('ref'),
+    ])
+  })
+})

--- a/src/lib/maskPreprocess.ts
+++ b/src/lib/maskPreprocess.ts
@@ -1,0 +1,120 @@
+import type { InputImage } from '../types'
+import { canvasToBlob, loadImage } from './canvasImage'
+
+export const DEFAULT_MASK_WORKING_MAX_EDGE = 1920
+export const MASK_WORKING_DIMENSION_MULTIPLE = 16
+
+export interface MaskWorkingSize {
+  width: number
+  height: number
+  scale: number
+  wasResized: boolean
+}
+
+export interface PreparedMaskTarget extends MaskWorkingSize {
+  dataUrl: string
+  originalWidth: number
+  originalHeight: number
+  wasConvertedToPng: boolean
+}
+
+function floorToMultiple(value: number, multiple: number): number {
+  return Math.max(multiple, Math.floor(value / multiple) * multiple)
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(String(reader.result))
+    reader.onerror = () => reject(reader.error ?? new Error('图片导出失败'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+export function calculateMaskWorkingSize(
+  width: number,
+  height: number,
+  maxEdge = DEFAULT_MASK_WORKING_MAX_EDGE,
+  multiple = MASK_WORKING_DIMENSION_MULTIPLE,
+): MaskWorkingSize {
+  const longestEdge = Math.max(width, height)
+  if (longestEdge <= maxEdge) {
+    return {
+      width,
+      height,
+      scale: 1,
+      wasResized: false,
+    }
+  }
+
+  const scale = maxEdge / longestEdge
+  return {
+    width: floorToMultiple(width * scale, multiple),
+    height: floorToMultiple(height * scale, multiple),
+    scale,
+    wasResized: true,
+  }
+}
+
+export async function prepareMaskTargetDataUrl(dataUrl: string): Promise<PreparedMaskTarget> {
+  const image = await loadImage(dataUrl)
+  const size = calculateMaskWorkingSize(image.naturalWidth, image.naturalHeight)
+  const isPng = /^data:image\/png(?:[;,]|$)/i.test(dataUrl)
+
+  if (!size.wasResized && isPng) {
+    return {
+      ...size,
+      dataUrl,
+      originalWidth: image.naturalWidth,
+      originalHeight: image.naturalHeight,
+      wasConvertedToPng: false,
+    }
+  }
+
+  const canvas = document.createElement('canvas')
+  canvas.width = size.width
+  canvas.height = size.height
+  const ctx = canvas.getContext('2d')
+  if (!ctx) throw new Error('当前浏览器不支持 Canvas')
+  ctx.drawImage(image, 0, 0, size.width, size.height)
+
+  const blob = await canvasToBlob(canvas, 'image/png')
+  return {
+    ...size,
+    dataUrl: await blobToDataUrl(blob),
+    originalWidth: image.naturalWidth,
+    originalHeight: image.naturalHeight,
+    wasConvertedToPng: true,
+  }
+}
+
+export function replaceMaskTargetImage(
+  inputImages: InputImage[],
+  targetImageId: string,
+  workingImage: InputImage,
+): InputImage[] {
+  const nextImages: InputImage[] = []
+  let inserted = false
+
+  for (const image of inputImages) {
+    if (image.id === targetImageId) {
+      if (!inserted) {
+        nextImages.push(workingImage)
+        inserted = true
+      }
+      continue
+    }
+
+    if (image.id === workingImage.id) {
+      if (!inserted) {
+        nextImages.push(workingImage)
+        inserted = true
+      }
+      continue
+    }
+
+    nextImages.push(image)
+  }
+
+  return inserted ? nextImages : [workingImage, ...nextImages]
+}

--- a/src/lib/viewportTransform.test.ts
+++ b/src/lib/viewportTransform.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clampViewTransform,
+  clientPointToCanvasPoint,
+  getComfortableInitialTransform,
+  getPinchTransform,
+  zoomAtPoint,
+} from './viewportTransform'
+
+describe('viewport transform helpers', () => {
+  it('keeps an unzoomed canvas centered by clamping offsets to zero', () => {
+    expect(clampViewTransform({ scale: 1, x: -80, y: 40 }, { width: 300, height: 200 })).toEqual({
+      scale: 1,
+      x: 0,
+      y: 0,
+    })
+  })
+
+  it('zooms around the requested point instead of drifting to an edge', () => {
+    expect(zoomAtPoint(
+      { scale: 1, x: 0, y: 0 },
+      { x: 150, y: 100 },
+      2,
+      { width: 300, height: 200 },
+    )).toEqual({
+      scale: 2,
+      x: -150,
+      y: -100,
+    })
+  })
+
+  it('combines two-finger pinch zoom and pan around the original centroid', () => {
+    expect(getPinchTransform({
+      startTransform: { scale: 1, x: 0, y: 0 },
+      startCentroid: { x: 150, y: 100 },
+      nextCentroid: { x: 160, y: 120 },
+      startDistance: 100,
+      nextDistance: 200,
+      viewportSize: { width: 300, height: 200 },
+    })).toEqual({
+      scale: 2,
+      x: -140,
+      y: -80,
+    })
+  })
+
+  it('maps transformed client coordinates back to natural canvas pixels', () => {
+    expect(clientPointToCanvasPoint(
+      { left: 10, top: 20, width: 200, height: 100 },
+      { x: 110, y: 70 },
+      { width: 1000, height: 500 },
+    )).toEqual({
+      x: 500,
+      y: 250,
+    })
+  })
+
+  it('starts compact wide images zoomed enough to be drawable', () => {
+    const transform = getComfortableInitialTransform(
+      { width: 356, height: 116 },
+      { width: 374, height: 642 },
+      true,
+    )
+
+    expect(transform.scale).toBeCloseTo(2.32, 2)
+    expect(transform.x).toBeCloseTo(-236, 0)
+    expect(transform.y).toBeCloseTo(-77, 0)
+  })
+
+  it('keeps desktop initial view unzoomed', () => {
+    expect(getComfortableInitialTransform(
+      { width: 356, height: 116 },
+      { width: 900, height: 620 },
+      false,
+    )).toEqual({ scale: 1, x: 0, y: 0 })
+  })
+})

--- a/src/lib/viewportTransform.ts
+++ b/src/lib/viewportTransform.ts
@@ -1,0 +1,110 @@
+export interface Point {
+  x: number
+  y: number
+}
+
+export interface Size {
+  width: number
+  height: number
+}
+
+export interface ViewTransform {
+  scale: number
+  x: number
+  y: number
+}
+
+export interface ClientRectLike {
+  left: number
+  top: number
+  width: number
+  height: number
+}
+
+const MIN_SCALE = 1
+const MAX_SCALE = 6
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}
+
+export function clampViewTransform(transform: ViewTransform, viewportSize: Size): ViewTransform {
+  const scale = clamp(transform.scale, MIN_SCALE, MAX_SCALE)
+
+  if (scale === MIN_SCALE) {
+    return { scale, x: 0, y: 0 }
+  }
+
+  return {
+    scale,
+    x: clamp(transform.x, viewportSize.width * (1 - scale), 0),
+    y: clamp(transform.y, viewportSize.height * (1 - scale), 0),
+  }
+}
+
+export function zoomAtPoint(
+  transform: ViewTransform,
+  point: Point,
+  nextScale: number,
+  viewportSize: Size,
+): ViewTransform {
+  const localPoint = {
+    x: (point.x - transform.x) / transform.scale,
+    y: (point.y - transform.y) / transform.scale,
+  }
+  const scale = clamp(nextScale, MIN_SCALE, MAX_SCALE)
+
+  return clampViewTransform({
+    scale,
+    x: point.x - localPoint.x * scale,
+    y: point.y - localPoint.y * scale,
+  }, viewportSize)
+}
+
+export function getPinchTransform(input: {
+  startTransform: ViewTransform
+  startCentroid: Point
+  nextCentroid: Point
+  startDistance: number
+  nextDistance: number
+  viewportSize: Size
+}): ViewTransform {
+  const localPoint = {
+    x: (input.startCentroid.x - input.startTransform.x) / input.startTransform.scale,
+    y: (input.startCentroid.y - input.startTransform.y) / input.startTransform.scale,
+  }
+  const distanceRatio = input.startDistance > 0 ? input.nextDistance / input.startDistance : 1
+  const scale = clamp(input.startTransform.scale * distanceRatio, MIN_SCALE, MAX_SCALE)
+
+  return clampViewTransform({
+    scale,
+    x: input.nextCentroid.x - localPoint.x * scale,
+    y: input.nextCentroid.y - localPoint.y * scale,
+  }, input.viewportSize)
+}
+
+export function clientPointToCanvasPoint(rect: ClientRectLike, point: Point, canvasSize: Size): Point {
+  return {
+    x: ((point.x - rect.left) / rect.width) * canvasSize.width,
+    y: ((point.y - rect.top) / rect.height) * canvasSize.height,
+  }
+}
+
+export function getComfortableInitialTransform(
+  imageViewportSize: Size,
+  editorViewportSize: Size,
+  isCompactLayout: boolean,
+): ViewTransform {
+  if (!isCompactLayout || imageViewportSize.width <= 0 || imageViewportSize.height <= 0) {
+    return { scale: MIN_SCALE, x: 0, y: 0 }
+  }
+
+  const targetHeight = editorViewportSize.height * 0.42
+  const scale = clamp(targetHeight / imageViewportSize.height, MIN_SCALE, 3)
+  return zoomAtPoint(
+    { scale: MIN_SCALE, x: 0, y: 0 },
+    { x: imageViewportSize.width / 2, y: imageViewportSize.height / 2 },
+    scale,
+    imageViewportSize,
+  )
+}

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { DEFAULT_PARAMS, DEFAULT_SETTINGS } from './types'
+import type { TaskRecord } from './types'
+import { editOutputs, submitTask, useStore } from './store'
+
+const imageA = { id: 'image-a', dataUrl: 'data:image/png;base64,a' }
+
+function task(overrides: Partial<TaskRecord> = {}): TaskRecord {
+  return {
+    id: 'task-a',
+    prompt: 'prompt',
+    params: { ...DEFAULT_PARAMS },
+    inputImageIds: [],
+    maskTargetImageId: null,
+    maskImageId: null,
+    outputImages: [],
+    status: 'done',
+    error: null,
+    createdAt: 1,
+    finishedAt: 2,
+    elapsed: 1,
+    ...overrides,
+  }
+}
+
+describe('mask draft lifecycle in store actions', () => {
+  beforeEach(() => {
+    useStore.setState({
+      settings: { ...DEFAULT_SETTINGS, apiKey: 'test-key' },
+      prompt: 'prompt',
+      inputImages: [],
+      maskDraft: null,
+      maskEditorImageId: null,
+      params: { ...DEFAULT_PARAMS },
+      tasks: [],
+      detailTaskId: null,
+      lightboxImageId: null,
+      lightboxImageList: [],
+      showSettings: false,
+      toast: null,
+      confirmDialog: null,
+      showToast: vi.fn(),
+      setConfirmDialog: vi.fn(),
+    })
+  })
+
+  it('clears an existing mask when quick edit-output adds outputs as references', async () => {
+    useStore.setState({
+      inputImages: [imageA],
+      maskDraft: {
+        targetImageId: imageA.id,
+        maskDataUrl: 'data:image/png;base64,mask',
+        updatedAt: 1,
+      },
+    })
+
+    await editOutputs(task({ outputImages: [imageA.id] }))
+
+    expect(useStore.getState().maskDraft).toBeNull()
+  })
+
+  it('clears an invalid mask draft when submit cannot find the mask target image', async () => {
+    useStore.setState({
+      inputImages: [imageA],
+      maskDraft: {
+        targetImageId: 'missing-image',
+        maskDataUrl: 'data:image/png;base64,mask',
+        updatedAt: 1,
+      },
+    })
+
+    await submitTask()
+
+    expect(useStore.getState().maskDraft).toBeNull()
+  })
+})

--- a/src/store.ts
+++ b/src/store.ts
@@ -4,6 +4,7 @@ import type {
   AppSettings,
   TaskParams,
   InputImage,
+  MaskDraft,
   TaskRecord,
   ExportData,
 } from './types'
@@ -23,6 +24,8 @@ import {
 } from './lib/db'
 import { callImageApi } from './lib/api'
 import { normalizeImageSize } from './lib/size'
+import { validateMaskMatchesImage } from './lib/canvasImage'
+import { orderInputImagesForMask } from './lib/mask'
 import { zipSync, unzipSync, strToU8, strFromU8 } from 'fflate'
 
 // ===== Image cache =====
@@ -62,6 +65,11 @@ interface AppState {
   removeInputImage: (idx: number) => void
   clearInputImages: () => void
   setInputImages: (imgs: InputImage[]) => void
+  maskDraft: MaskDraft | null
+  setMaskDraft: (draft: MaskDraft | null) => void
+  clearMaskDraft: () => void
+  maskEditorImageId: string | null
+  setMaskEditorImageId: (id: string | null) => void
 
   // 参数
   params: TaskParams
@@ -146,15 +154,33 @@ export const useStore = create<AppState>()(
           return { inputImages: [...s.inputImages, img] }
         }),
       removeInputImage: (idx) =>
-        set((s) => ({
-          inputImages: s.inputImages.filter((_, i) => i !== idx),
-        })),
+        set((s) => {
+          const removed = s.inputImages[idx]
+          const shouldClearMask = removed?.id === s.maskDraft?.targetImageId
+          return {
+            inputImages: s.inputImages.filter((_, i) => i !== idx),
+            ...(shouldClearMask ? { maskDraft: null, maskEditorImageId: null } : {}),
+          }
+        }),
       clearInputImages: () =>
         set((s) => {
           for (const img of s.inputImages) imageCache.delete(img.id)
-          return { inputImages: [] }
+          return { inputImages: [], maskDraft: null, maskEditorImageId: null }
         }),
-      setInputImages: (imgs) => set({ inputImages: imgs }),
+      setInputImages: (imgs) =>
+        set((s) => {
+          const shouldClearMask =
+            Boolean(s.maskDraft) && !imgs.some((img) => img.id === s.maskDraft?.targetImageId)
+          return {
+            inputImages: imgs,
+            ...(shouldClearMask ? { maskDraft: null, maskEditorImageId: null } : {}),
+          }
+        }),
+      maskDraft: null,
+      setMaskDraft: (maskDraft) => set({ maskDraft }),
+      clearMaskDraft: () => set({ maskDraft: null }),
+      maskEditorImageId: null,
+      setMaskEditorImageId: (maskEditorImageId) => set({ maskEditorImageId }),
 
       // Params
       params: { ...DEFAULT_PARAMS },
@@ -262,6 +288,7 @@ export async function initStore() {
   const referencedIds = new Set<string>()
   for (const t of tasks) {
     for (const id of t.inputImageIds || []) referencedIds.add(id)
+    if (t.maskImageId) referencedIds.add(t.maskImageId)
     for (const id of t.outputImages || []) referencedIds.add(id)
   }
 
@@ -277,8 +304,8 @@ export async function initStore() {
 }
 
 /** 提交新任务 */
-export async function submitTask() {
-  const { settings, prompt, inputImages, params, tasks, setTasks, showToast } =
+export async function submitTask(options: { allowFullMask?: boolean } = {}) {
+  const { settings, prompt, inputImages, maskDraft, params, showToast, setConfirmDialog } =
     useStore.getState()
 
   if (!settings.apiKey) {
@@ -292,8 +319,39 @@ export async function submitTask() {
     return
   }
 
+  let orderedInputImages = inputImages
+  let maskImageId: string | null = null
+  let maskTargetImageId: string | null = null
+
+  if (maskDraft) {
+    try {
+      orderedInputImages = orderInputImagesForMask(inputImages, maskDraft.targetImageId)
+      const coverage = await validateMaskMatchesImage(maskDraft.maskDataUrl, orderedInputImages[0].dataUrl)
+      if (coverage === 'full' && !options.allowFullMask) {
+        setConfirmDialog({
+          title: '确认编辑整张图片？',
+          message: '当前遮罩覆盖了整张图片，提交后可能会重绘全部内容。是否继续？',
+          confirmText: '继续提交',
+          action: () => {
+            void submitTask({ allowFullMask: true })
+          },
+        })
+        return
+      }
+      maskImageId = await storeImage(maskDraft.maskDataUrl, 'mask')
+      imageCache.set(maskImageId, maskDraft.maskDataUrl)
+      maskTargetImageId = maskDraft.targetImageId
+    } catch (err) {
+      if (!inputImages.some((img) => img.id === maskDraft.targetImageId)) {
+        useStore.getState().clearMaskDraft()
+      }
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+      return
+    }
+  }
+
   // 持久化输入图片到 IndexedDB（此前只在内存缓存中）
-  for (const img of inputImages) {
+  for (const img of orderedInputImages) {
     await storeImage(img.dataUrl)
   }
 
@@ -311,7 +369,9 @@ export async function submitTask() {
     id: taskId,
     prompt: prompt.trim(),
     params: normalizedParams,
-    inputImageIds: inputImages.map((i) => i.id),
+    inputImageIds: orderedInputImages.map((i) => i.id),
+    maskTargetImageId,
+    maskImageId,
     outputImages: [],
     status: 'running',
     error: null,
@@ -320,8 +380,8 @@ export async function submitTask() {
     elapsed: null,
   }
 
-  const newTasks = [task, ...tasks]
-  setTasks(newTasks)
+  const latestTasks = useStore.getState().tasks
+  useStore.getState().setTasks([task, ...latestTasks])
   await putTask(task)
 
   // 异步调用 API
@@ -338,7 +398,13 @@ async function executeTask(taskId: string) {
     const inputDataUrls: string[] = []
     for (const imgId of task.inputImageIds) {
       const dataUrl = await ensureImageCached(imgId)
-      if (dataUrl) inputDataUrls.push(dataUrl)
+      if (!dataUrl) throw new Error('输入图片已不存在')
+      inputDataUrls.push(dataUrl)
+    }
+    let maskDataUrl: string | undefined
+    if (task.maskImageId) {
+      maskDataUrl = await ensureImageCached(task.maskImageId)
+      if (!maskDataUrl) throw new Error('遮罩图片已不存在')
     }
 
     const result = await callImageApi({
@@ -346,6 +412,7 @@ async function executeTask(taskId: string) {
       prompt: task.prompt,
       params: task.params,
       inputImageDataUrls: inputDataUrls,
+      maskDataUrl,
     })
 
     // 存储输出图片
@@ -389,6 +456,15 @@ async function executeTask(taskId: string) {
     })
 
     useStore.getState().showToast(`生成完成，共 ${outputIds.length} 张图片`, 'success')
+    const currentMask = useStore.getState().maskDraft
+    if (
+      maskDataUrl &&
+      currentMask &&
+      currentMask.targetImageId === task.maskTargetImageId &&
+      currentMask.maskDataUrl === maskDataUrl
+    ) {
+      useStore.getState().clearMaskDraft()
+    }
   } catch (err) {
     updateTaskInStore(taskId, {
       status: 'error',
@@ -417,7 +493,7 @@ export function updateTaskInStore(taskId: string, patch: Partial<TaskRecord>) {
 
 /** 复用配置 */
 export async function reuseConfig(task: TaskRecord) {
-  const { setPrompt, setParams, setInputImages, showToast } = useStore.getState()
+  const { setPrompt, setParams, setInputImages, setMaskDraft, clearMaskDraft, showToast } = useStore.getState()
   setPrompt(task.prompt)
   setParams(task.params)
 
@@ -430,14 +506,29 @@ export async function reuseConfig(task: TaskRecord) {
     }
   }
   setInputImages(imgs)
+  if (task.maskTargetImageId && task.maskImageId && imgs.some((img) => img.id === task.maskTargetImageId)) {
+    const maskDataUrl = await ensureImageCached(task.maskImageId)
+    if (maskDataUrl) {
+      setMaskDraft({
+        targetImageId: task.maskTargetImageId,
+        maskDataUrl,
+        updatedAt: Date.now(),
+      })
+    } else {
+      clearMaskDraft()
+    }
+  } else {
+    clearMaskDraft()
+  }
   showToast('已复用配置到输入框', 'success')
 }
 
 /** 编辑输出：将输出图加入输入 */
 export async function editOutputs(task: TaskRecord) {
-  const { inputImages, addInputImage, showToast } = useStore.getState()
+  const { inputImages, addInputImage, clearMaskDraft, showToast } = useStore.getState()
   if (!task.outputImages?.length) return
 
+  clearMaskDraft()
   let added = 0
   for (const imgId of task.outputImages) {
     if (inputImages.find((i) => i.id === imgId)) continue
@@ -464,6 +555,7 @@ export async function removeMultipleTasks(taskIds: string[]) {
   for (const t of tasks) {
     if (toDelete.has(t.id)) {
       for (const id of t.inputImageIds || []) deletedImageIds.add(id)
+      if (t.maskImageId) deletedImageIds.add(t.maskImageId)
       for (const id of t.outputImages || []) deletedImageIds.add(id)
     }
   }
@@ -477,6 +569,7 @@ export async function removeMultipleTasks(taskIds: string[]) {
   const stillUsed = new Set<string>()
   for (const t of remaining) {
     for (const id of t.inputImageIds || []) stillUsed.add(id)
+    if (t.maskImageId) stillUsed.add(t.maskImageId)
     for (const id of t.outputImages || []) stillUsed.add(id)
   }
   for (const img of inputImages) stillUsed.add(img.id)
@@ -505,6 +598,7 @@ export async function removeTask(task: TaskRecord) {
   // 收集此任务关联的图片
   const taskImageIds = new Set([
     ...(task.inputImageIds || []),
+    ...(task.maskImageId ? [task.maskImageId] : []),
     ...(task.outputImages || []),
   ])
 
@@ -517,6 +611,7 @@ export async function removeTask(task: TaskRecord) {
   const stillUsed = new Set<string>()
   for (const t of remaining) {
     for (const id of t.inputImageIds || []) stillUsed.add(id)
+    if (t.maskImageId) stillUsed.add(t.maskImageId)
     for (const id of t.outputImages || []) stillUsed.add(id)
   }
   for (const img of inputImages) stillUsed.add(img.id)
@@ -537,9 +632,10 @@ export async function clearAllData() {
   await dbClearTasks()
   await clearImages()
   imageCache.clear()
-  const { setTasks, clearInputImages, setSettings, setParams, showToast } = useStore.getState()
+  const { setTasks, clearInputImages, clearMaskDraft, setSettings, setParams, showToast } = useStore.getState()
   setTasks([])
   clearInputImages()
+  clearMaskDraft()
   useStore.setState({ dismissedCodexCliPrompts: [] })
   setSettings({ ...DEFAULT_SETTINGS })
   setParams({ ...DEFAULT_PARAMS })
@@ -577,7 +673,11 @@ export async function exportData() {
     const imageCreatedAtFallback = new Map<string, number>()
 
     for (const task of tasks) {
-      for (const id of [...(task.inputImageIds || []), ...(task.outputImages || [])]) {
+      for (const id of [
+        ...(task.inputImageIds || []),
+        ...(task.maskImageId ? [task.maskImageId] : []),
+        ...(task.outputImages || []),
+      ]) {
         const prev = imageCreatedAtFallback.get(id)
         if (prev == null || task.createdAt < prev) {
           imageCreatedAtFallback.set(id, task.createdAt)

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,14 @@ export interface InputImage {
   dataUrl: string
 }
 
+export interface MaskDraft {
+  /** 将作为 images/edits 第一张 image[] 的输入图 id */
+  targetImageId: string
+  /** 与遮罩主图同尺寸的 PNG data URL；透明区域会被编辑 */
+  maskDataUrl: string
+  updatedAt: number
+}
+
 // ===== 任务记录 =====
 
 export type TaskStatus = 'running' | 'done' | 'error'
@@ -69,6 +77,10 @@ export interface TaskRecord {
   revisedPromptByImage?: Record<string, string>
   /** 输入图片的 image store id 列表 */
   inputImageIds: string[]
+  /** 遮罩编辑时真正被 mask 作用的输入图 id，必须对应 inputImageIds[0] */
+  maskTargetImageId?: string | null
+  /** 遮罩 PNG 的 image store id */
+  maskImageId?: string | null
   /** 输出图片的 image store id 列表 */
   outputImages: string[]
   status: TaskStatus
@@ -88,8 +100,8 @@ export interface StoredImage {
   dataUrl: string
   /** 图片首次存储时间（ms） */
   createdAt?: number
-  /** 图片来源：用户上传 / API 生成 */
-  source?: 'upload' | 'generated'
+  /** 图片来源：用户上传 / 遮罩 / API 生成 */
+  source?: 'upload' | 'mask' | 'generated'
 }
 
 // ===== API 请求体 =====
@@ -168,6 +180,6 @@ export interface ExportData {
   imageFiles: Record<string, {
     path: string
     createdAt?: number
-    source?: 'upload' | 'generated'
+    source?: 'upload' | 'mask' | 'generated'
   }>
 }


### PR DESCRIPTION
## Summary
- Add a brush/eraser mask editor for image edit inputs
- Keep the masked image as the first edit input and preserve additional reference images
- Convert mask targets to safe PNG working images for mask edits, with mobile pinch zoom/pan support
- Show mask context in task history and detail views

## Verification
- npm run test
- npm run build