### PR TITLE
fix: adjust header safe area for iOS PWA

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -74,7 +74,7 @@ export default function App() {
   return (
     <>
       <Header />
-      <main className="max-w-7xl mx-auto px-4 pb-48">
+      <main className="safe-area-x max-w-7xl mx-auto pb-48">
         <SearchBar />
         <TaskGrid />
       </main>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,8 +9,8 @@ export default function Header() {
   const [showHelp, setShowHelp] = useState(false)
 
   return (
-    <header className="sticky top-0 z-40 bg-white/80 dark:bg-gray-950/80 backdrop-blur border-b border-gray-200 dark:border-white/[0.08]">
-      <div className="max-w-7xl mx-auto px-4 h-14 flex items-center justify-between">
+    <header className="safe-area-top sticky top-0 z-40 bg-white/80 dark:bg-gray-950/80 backdrop-blur border-b border-gray-200 dark:border-white/[0.08]">
+      <div className="safe-area-x safe-header-inner max-w-7xl mx-auto flex items-center justify-between">
         <div className="flex items-start gap-1">
           <h1 className="text-lg font-bold tracking-tight">
             <a

--- a/src/index.css
+++ b/src/index.css
@@ -8,11 +8,19 @@
 :root {
   --font-ui-sans: 'HarmonyOS Sans SC', 'Noto Sans SC', 'PingFang SC', 'Microsoft YaHei', sans-serif;
   --font-mono: 'Maple Mono', 'Cascadia Code', 'SF Mono', Menlo, Consolas, monospace;
+  --safe-area-top: env(safe-area-inset-top, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
+  --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
   scrollbar-gutter: stable;
 }
 
 html {
   overflow-y: scroll;
+}
+
+body {
+  padding: 0;
 }
 
 * {
@@ -172,6 +180,19 @@ input[type="number"] {
 .animate-dropdown-up {
   transform-origin: bottom center;
   animation: dropdown-up 0.15s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+
+.safe-area-x {
+  padding-left: max(1rem, var(--safe-area-left));
+  padding-right: max(1rem, var(--safe-area-right));
+}
+
+.safe-area-top {
+  padding-top: var(--safe-area-top);
+}
+
+.safe-header-inner {
+  min-height: 3.5rem;
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
## 优化iOS端pwa界面全屏导致设置按钮无法点击。
### 原状态：
<img width="316" height="93" alt="Photos_2026_04_28_754" src="https://github.com/user-attachments/assets/665bb90c-d7ef-445c-9a51-b636e935c315" />

### 优化后与刘海区域保持安全距离：
<img width="316" height="93" alt="image" src="https://github.com/user-attachments/assets/fa6457a5-27d6-415a-851a-eb9cd35e658b" />

### 已经过测试，未发现因修改导致的其它ui问题。
