### PR TITLE
feat(input): 支持拖拽排序参考图

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -75,9 +75,11 @@ export default function App() {
   return (
     <>
       <Header />
-      <main data-home-main className="safe-area-x max-w-7xl mx-auto pb-48">
-        <SearchBar />
-        <TaskGrid />
+      <main data-home-main data-drag-select-surface className="pb-48">
+        <div className="safe-area-x max-w-7xl mx-auto">
+          <SearchBar />
+          <TaskGrid />
+        </div>
       </main>
       <InputBar />
       <DetailModal />

--- a/src/components/DetailModal.tsx
+++ b/src/components/DetailModal.tsx
@@ -300,7 +300,7 @@ export default function DetailModal() {
                 }
                 alt=""
               />
-              <div className="absolute top-[15px] flex items-center gap-1.5" style={{ left: imageLabelLeft }}>
+              <div data-selectable-text className="absolute top-[15px] flex items-center gap-1.5" style={{ left: imageLabelLeft }}>
                 {currentImageRatio && currentImageSize ? (
                   <>
                     <span className="bg-black/50 text-white text-xs px-2 py-0.5 rounded backdrop-blur-sm font-mono">
@@ -409,7 +409,7 @@ export default function DetailModal() {
             </svg>
           </button>
 
-          <div className="flex-1">
+          <div data-selectable-text className="flex-1">
             <div className="flex items-center gap-1.5 mb-2">
               <h3 className="text-xs font-medium text-gray-400 dark:text-gray-500 uppercase tracking-wider">
                 输入内容

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,7 +9,7 @@ export default function Header() {
   const [showHelp, setShowHelp] = useState(false)
 
   return (
-    <header className="safe-area-top sticky top-0 z-40 bg-white/80 dark:bg-gray-950/80 backdrop-blur border-b border-gray-200 dark:border-white/[0.08]">
+    <header data-no-drag-select className="safe-area-top sticky top-0 z-40 bg-white/80 dark:bg-gray-950/80 backdrop-blur border-b border-gray-200 dark:border-white/[0.08]">
       <div className="safe-area-x safe-header-inner max-w-7xl mx-auto flex items-center justify-between">
         <div className="flex items-start gap-1">
           <h1 className="text-lg font-bold tracking-tight">

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -107,6 +107,7 @@ export default function InputBar() {
   const maskDraft = useStore((s) => s.maskDraft)
   const clearMaskDraft = useStore((s) => s.clearMaskDraft)
   const setMaskEditorImageId = useStore((s) => s.setMaskEditorImageId)
+  const moveInputImage = useStore((s) => s.moveInputImage)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
@@ -123,6 +124,8 @@ export default function InputBar() {
   const [mobileCollapsed, setMobileCollapsed] = useState(false)
   const [showSizePicker, setShowSizePicker] = useState(false)
   const [maskPreviewUrl, setMaskPreviewUrl] = useState('')
+  const [dragIndex, setDragIndex] = useState<number | null>(null)
+  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const handleRef = useRef<HTMLDivElement>(null)
   const dragTouchRef = useRef({ startY: 0, moved: false })
   const compressionHintTimerRef = useRef<number | null>(null)
@@ -487,23 +490,71 @@ export default function InputBar() {
 
   const selectClass = 'px-3 py-1.5 rounded-xl border border-gray-200/60 dark:border-white/[0.08] bg-white/50 dark:bg-white/[0.03] hover:bg-white dark:hover:bg-white/[0.06] text-xs transition-all duration-200 shadow-sm'
 
-  const renderImageThumb = (img: (typeof inputImages)[number]) => {
-    const originalIndex = inputImages.findIndex((i) => i.id === img.id)
+  const renderImageThumb = (img: (typeof inputImages)[number], idx: number) => {
     const isMaskTarget = maskDraft?.targetImageId === img.id
     const canEdit = !maskTargetImage || isMaskTarget
     const displaySrc = isMaskTarget && maskPreviewUrl ? maskPreviewUrl : img.dataUrl
+    const isDragging = dragIndex === idx
+    const isLast = idx === inputImages.length - 1
+    const showDropBefore = dragOverIndex === idx && dragIndex !== idx
+    const showDropAfter = dragOverIndex === inputImages.length && isLast && dragIndex !== idx
+
+    const handleDragStart = (e: React.DragEvent) => {
+      setDragIndex(idx)
+      e.dataTransfer.effectAllowed = 'move'
+      e.dataTransfer.setData('text/plain', String(idx))
+    }
+
+    const handleDragOver = (e: React.DragEvent) => {
+      e.preventDefault()
+      e.dataTransfer.dropEffect = 'move'
+      if (dragIndex === null || dragIndex === idx) return
+      const rect = e.currentTarget.getBoundingClientRect()
+      const midX = rect.left + rect.width / 2
+      setDragOverIndex(e.clientX < midX ? idx : idx + 1)
+    }
+
+    const handleDrop = (e: React.DragEvent) => {
+      e.preventDefault()
+      if (dragIndex !== null && dragIndex !== idx) {
+        const rect = e.currentTarget.getBoundingClientRect()
+        const midX = rect.left + rect.width / 2
+        moveInputImage(dragIndex, e.clientX < midX ? idx : idx + 1)
+      }
+      setDragIndex(null)
+      setDragOverIndex(null)
+    }
+
+    const handleDragEnd = () => {
+      setDragIndex(null)
+      setDragOverIndex(null)
+    }
 
     return (
-      <div key={img.id} className="relative group inline-block">
+      <div
+        key={img.id}
+        className={`relative group inline-block shrink-0 transition-opacity ${isDragging ? 'opacity-40' : ''}`}
+        draggable
+        onDragStart={handleDragStart}
+        onDragOver={handleDragOver}
+        onDrop={handleDrop}
+        onDragEnd={handleDragEnd}
+      >
         <div 
-          className={`relative w-[52px] h-[52px] rounded-xl overflow-hidden border shadow-sm cursor-pointer ${
-            isMaskTarget ? 'border-blue-500 border-2' : 'border-gray-200 dark:border-white/[0.08]'
+          className={`relative w-[52px] h-[52px] rounded-xl overflow-hidden shadow-sm cursor-grab active:cursor-grabbing ${
+            showDropBefore
+              ? 'border-l-2 border-blue-500'
+              : showDropAfter
+                ? 'border-r-2 border-blue-500'
+                : isMaskTarget
+                  ? 'border-2 border-blue-500'
+                  : 'border border-gray-200 dark:border-white/[0.08]'
           }`}
           onClick={() => setLightboxImageId(img.id, inputImages.map((i) => i.id))}
         >
           <img
             src={displaySrc}
-            className="w-full h-full object-cover hover:opacity-90 transition-opacity"
+            className="w-full h-full object-cover hover:opacity-90 transition-opacity pointer-events-none"
             alt=""
           />
           {isMaskTarget && (
@@ -530,7 +581,7 @@ export default function InputBar() {
           className="absolute -top-2 -right-2 w-[22px] h-[22px] rounded-full bg-red-500 text-white flex items-center justify-center cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity shadow-md hover:bg-red-600 z-30"
           onClick={(e) => {
             e.stopPropagation()
-            if (originalIndex >= 0) removeInputImage(originalIndex)
+            removeInputImage(idx)
           }}
         >
           <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -566,7 +617,7 @@ export default function InputBar() {
     return (
       <div ref={imagesRef}>
         <div className="grid grid-cols-[repeat(auto-fill,52px)] justify-between gap-x-2 gap-y-3 mb-3">
-          {inputImages.map((img) => renderImageThumb(img))}
+          {inputImages.map((img, idx) => renderImageThumb(img, idx))}
           {renderClearAllButton()}
         </div>
       </div>

--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -1,21 +1,19 @@
 import { useRef, useEffect, useCallback, useState, useMemo } from 'react'
+import { createPortal } from 'react-dom'
 import { useStore, submitTask, addImageFromFile, updateTaskInStore, removeMultipleTasks } from '../store'
 import { DEFAULT_PARAMS } from '../types'
 import { normalizeImageSize } from '../lib/size'
 import { createMaskPreviewDataUrl } from '../lib/canvasImage'
 import Select from './Select'
 import SizePickerModal from './SizePickerModal'
+import ViewportTooltip from './ViewportTooltip'
 
 /** 通用悬浮气泡提示 */
 function ButtonTooltip({ visible, text }: { visible: boolean; text: string }) {
-  if (!visible) return null
   return (
-    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 pointer-events-none z-10 whitespace-nowrap">
-      <div className="relative bg-gray-800 text-white text-xs rounded-lg px-3 py-2 shadow-lg">
-        {text}
-        <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800" />
-      </div>
-    </div>
+    <ViewportTooltip visible={visible} className="z-10 whitespace-nowrap">
+      {text}
+    </ViewportTooltip>
   )
 }
 
@@ -43,6 +41,7 @@ export default function InputBar() {
   const settings = useStore((s) => s.settings)
   const setShowSettings = useStore((s) => s.setShowSettings)
   const setLightboxImageId = useStore((s) => s.setLightboxImageId)
+  const showToast = useStore((s) => s.showToast)
   const setConfirmDialog = useStore((s) => s.setConfirmDialog)
   const selectedTaskIds = useStore((s) => s.selectedTaskIds)
   const setSelectedTaskIds = useStore((s) => s.setSelectedTaskIds)
@@ -121,16 +120,25 @@ export default function InputBar() {
   const [compressionHintVisible, setCompressionHintVisible] = useState(false)
   const [moderationHintVisible, setModerationHintVisible] = useState(false)
   const [qualityHintVisible, setQualityHintVisible] = useState(false)
+  const [imageHintId, setImageHintId] = useState<string | null>(null)
   const [mobileCollapsed, setMobileCollapsed] = useState(false)
   const [showSizePicker, setShowSizePicker] = useState(false)
   const [maskPreviewUrl, setMaskPreviewUrl] = useState('')
-  const [dragIndex, setDragIndex] = useState<number | null>(null)
-  const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+  const [imageDragIndex, setImageDragIndex] = useState<number | null>(null)
+  const [imageDragOverIndex, setImageDragOverIndex] = useState<number | null>(null)
+  const [touchDragPreview, setTouchDragPreview] = useState<{ src: string; x: number; y: number } | null>(null)
   const handleRef = useRef<HTMLDivElement>(null)
   const dragTouchRef = useRef({ startY: 0, moved: false })
+  const imageDragIndexRef = useRef<number | null>(null)
+  const imageTouchDragRef = useRef({ index: null as number | null, startX: 0, startY: 0, moved: false })
+  const imageDragOverIndexRef = useRef<number | null>(null)
+  const imageDragPreviewRef = useRef<HTMLElement | null>(null)
+  const suppressImageClickRef = useRef(false)
+  const maskConflictNoticeShownRef = useRef(false)
   const compressionHintTimerRef = useRef<number | null>(null)
   const moderationHintTimerRef = useRef<number | null>(null)
   const qualityHintTimerRef = useRef<number | null>(null)
+  const imageHintTimerRef = useRef<number | null>(null)
   const [outputCompressionInput, setOutputCompressionInput] = useState(
     params.output_compression == null ? '' : String(params.output_compression),
   )
@@ -178,6 +186,9 @@ export default function InputBar() {
     }
     if (qualityHintTimerRef.current != null) {
       window.clearTimeout(qualityHintTimerRef.current)
+    }
+    if (imageHintTimerRef.current != null) {
+      window.clearTimeout(imageHintTimerRef.current)
     }
   }, [])
 
@@ -292,6 +303,28 @@ export default function InputBar() {
     qualityHintTimerRef.current = window.setTimeout(() => {
       setQualityHintVisible(true)
       qualityHintTimerRef.current = null
+    }, 450)
+  }
+
+  const clearImageHintTimer = () => {
+    if (imageHintTimerRef.current != null) {
+      window.clearTimeout(imageHintTimerRef.current)
+      imageHintTimerRef.current = null
+    }
+  }
+
+  const showImageHint = (id: string) => setImageHintId(id)
+
+  const hideImageHint = () => {
+    setImageHintId(null)
+    clearImageHintTimer()
+  }
+
+  const startImageHintTouch = (id: string) => {
+    clearImageHintTimer()
+    imageHintTimerRef.current = window.setTimeout(() => {
+      setImageHintId(id)
+      imageHintTimerRef.current = null
     }, 450)
   }
 
@@ -490,67 +523,223 @@ export default function InputBar() {
 
   const selectClass = 'px-3 py-1.5 rounded-xl border border-gray-200/60 dark:border-white/[0.08] bg-white/50 dark:bg-white/[0.03] hover:bg-white dark:hover:bg-white/[0.06] text-xs transition-all duration-200 shadow-sm'
 
+  const getTouchDropIndex = (touch: React.Touch) => {
+    const target = document
+      .elementFromPoint(touch.clientX, touch.clientY)
+      ?.closest<HTMLElement>('[data-input-image-index]')
+    if (!target) return null
+    const idx = Number(target.dataset.inputImageIndex)
+    if (!Number.isInteger(idx)) return null
+    const rect = target.getBoundingClientRect()
+    return touch.clientX < rect.left + rect.width / 2 ? idx : idx + 1
+  }
+
+  const normalizeImageDropIndex = (idx: number) => {
+    const minIdx = maskTargetImage ? 1 : 0
+    return Math.max(minIdx, Math.min(inputImages.length, idx))
+  }
+
+  const isBeforeMaskDropArea = (clientX: number) => {
+    if (!maskTargetImage) return false
+    const maskEl = document.querySelector<HTMLElement>('[data-input-image-index="0"]')
+    if (!maskEl) return false
+    const rect = maskEl.getBoundingClientRect()
+    return clientX < rect.left + rect.width / 2
+  }
+
+  const resetImageDrag = () => {
+    setImageDragIndex(null)
+    setImageDragOverIndex(null)
+    imageDragIndexRef.current = null
+    imageDragOverIndexRef.current = null
+    imageTouchDragRef.current = { index: null, startX: 0, startY: 0, moved: false }
+    setTouchDragPreview(null)
+    imageDragPreviewRef.current?.remove()
+    imageDragPreviewRef.current = null
+    hideImageHint()
+  }
+
+  useEffect(() => {
+    if (!touchDragPreview) return
+    const previousOverflow = document.body.style.overflow
+    const previousOverscroll = document.body.style.overscrollBehavior
+    document.body.style.overflow = 'hidden'
+    document.body.style.overscrollBehavior = 'none'
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.body.style.overscrollBehavior = previousOverscroll
+    }
+  }, [touchDragPreview])
+
+  const getDataTransferDragIndex = (e: React.DragEvent) => {
+    const value = e.dataTransfer.getData('text/plain')
+    const idx = Number(value)
+    return Number.isInteger(idx) ? idx : null
+  }
+
+  const setImageDragTarget = (idx: number | null, clientX?: number) => {
+    const fromIdx = imageDragIndexRef.current
+    if (fromIdx !== null && maskTargetImage && (idx === 0 || (clientX != null && isBeforeMaskDropArea(clientX)))) {
+      showImageHint(maskTargetImage.id)
+      imageDragOverIndexRef.current = null
+      setImageDragOverIndex(null)
+      return
+    }
+
+    if (fromIdx !== null) hideImageHint()
+    const normalizedIdx = idx == null ? null : normalizeImageDropIndex(idx)
+    const isNoopTarget = fromIdx !== null && normalizedIdx !== null && (normalizedIdx === fromIdx || normalizedIdx === fromIdx + 1)
+    const nextIdx = isNoopTarget ? null : normalizedIdx
+    imageDragOverIndexRef.current = nextIdx
+    setImageDragOverIndex(nextIdx)
+  }
+
   const renderImageThumb = (img: (typeof inputImages)[number], idx: number) => {
     const isMaskTarget = maskDraft?.targetImageId === img.id
     const canEdit = !maskTargetImage || isMaskTarget
+    const imageHintText = isMaskTarget
+      ? '遮罩图必须为第一张图'
+      : maskTargetImage
+        ? '只能有一张遮罩图'
+        : ''
     const displaySrc = isMaskTarget && maskPreviewUrl ? maskPreviewUrl : img.dataUrl
-    const isDragging = dragIndex === idx
+    const isImageDragging = imageDragIndex === idx
     const isLast = idx === inputImages.length - 1
-    const showDropBefore = dragOverIndex === idx && dragIndex !== idx
-    const showDropAfter = dragOverIndex === inputImages.length && isLast && dragIndex !== idx
+    const showDropBefore = imageDragOverIndex === idx && imageDragIndex !== idx
+    const showDropAfter = imageDragOverIndex === inputImages.length && isLast && imageDragIndex !== idx
 
     const handleDragStart = (e: React.DragEvent) => {
-      setDragIndex(idx)
+      if (isMaskTarget) {
+        e.preventDefault()
+        return
+      }
+      hideImageHint()
+      imageDragIndexRef.current = idx
+      setImageDragIndex(idx)
       e.dataTransfer.effectAllowed = 'move'
       e.dataTransfer.setData('text/plain', String(idx))
+      const preview = document.createElement('div')
+      preview.style.cssText = 'position:fixed;left:-1000px;top:-1000px;width:52px;height:52px;border-radius:12px;overflow:hidden;box-shadow:0 4px 12px rgba(0,0,0,0.25);'
+      const previewImg = document.createElement('img')
+      previewImg.src = displaySrc
+      previewImg.style.cssText = 'width:52px;height:52px;object-fit:cover;display:block;'
+      preview.appendChild(previewImg)
+      document.body.appendChild(preview)
+      imageDragPreviewRef.current = preview
+      e.dataTransfer.setDragImage(preview, 26, 26)
     }
 
     const handleDragOver = (e: React.DragEvent) => {
       e.preventDefault()
       e.dataTransfer.dropEffect = 'move'
-      if (dragIndex === null || dragIndex === idx) return
+      const fromIdx = imageDragIndexRef.current
+      if (fromIdx === null || fromIdx === idx) return
       const rect = e.currentTarget.getBoundingClientRect()
-      const midX = rect.left + rect.width / 2
-      setDragOverIndex(e.clientX < midX ? idx : idx + 1)
+      setImageDragTarget(e.clientX < rect.left + rect.width / 2 ? idx : idx + 1, e.clientX)
     }
 
     const handleDrop = (e: React.DragEvent) => {
       e.preventDefault()
-      if (dragIndex !== null && dragIndex !== idx) {
-        const rect = e.currentTarget.getBoundingClientRect()
-        const midX = rect.left + rect.width / 2
-        moveInputImage(dragIndex, e.clientX < midX ? idx : idx + 1)
+      const fromIdx = imageDragIndexRef.current ?? getDataTransferDragIndex(e)
+      const toIdx = imageDragOverIndexRef.current
+      if (fromIdx !== null && toIdx !== null) {
+        moveInputImage(fromIdx, toIdx)
       }
-      setDragIndex(null)
-      setDragOverIndex(null)
+      resetImageDrag()
     }
 
-    const handleDragEnd = () => {
-      setDragIndex(null)
-      setDragOverIndex(null)
+    const handleTouchStart = (e: React.TouchEvent) => {
+      if (isMaskTarget) {
+        startImageHintTouch(img.id)
+        return
+      }
+      const touch = e.touches[0]
+      imageDragIndexRef.current = idx
+      imageTouchDragRef.current = { index: idx, startX: touch.clientX, startY: touch.clientY, moved: false }
+      setTouchDragPreview(null)
+    }
+
+    const handleTouchMove = (e: React.TouchEvent) => {
+      const touch = e.touches[0]
+      const touchDrag = imageTouchDragRef.current
+      if (touchDrag.index === null) return
+
+      touchDrag.moved = true
+      clearImageHintTimer()
+      setImageHintId(null)
+      suppressImageClickRef.current = true
+      e.preventDefault()
+      setImageDragIndex(touchDrag.index)
+      setTouchDragPreview({ src: displaySrc, x: touch.clientX, y: touch.clientY })
+      const dropIndex = getTouchDropIndex(touch)
+      setImageDragTarget(dropIndex, touch.clientX)
+    }
+
+    const handleTouchEnd = (e: React.TouchEvent) => {
+      const touchDrag = imageTouchDragRef.current
+      clearImageHintTimer()
+      if (touchDrag.index !== null && imageDragOverIndexRef.current !== null) {
+        e.preventDefault()
+        moveInputImage(touchDrag.index, imageDragOverIndexRef.current)
+        window.setTimeout(() => {
+          suppressImageClickRef.current = false
+        }, 0)
+      }
+      resetImageDrag()
+    }
+
+    const handleTouchCancel = () => {
+      suppressImageClickRef.current = false
+      hideImageHint()
+      resetImageDrag()
     }
 
     return (
       <div
         key={img.id}
-        className={`relative group inline-block shrink-0 transition-opacity ${isDragging ? 'opacity-40' : ''}`}
-        draggable
+        data-input-image-index={idx}
+        className={`relative group inline-block shrink-0 transition-opacity ${isImageDragging ? 'opacity-40' : ''}`}
+        style={{ touchAction: isMaskTarget ? 'auto' : 'none' }}
+        draggable={!isMobile && !isMaskTarget}
+        onMouseEnter={() => imageHintText && (!isMobile || isMaskTarget) && showImageHint(img.id)}
+        onMouseLeave={hideImageHint}
         onDragStart={handleDragStart}
         onDragOver={handleDragOver}
         onDrop={handleDrop}
-        onDragEnd={handleDragEnd}
+        onDragEnd={resetImageDrag}
+        onTouchStart={handleTouchStart}
+        onTouchMove={handleTouchMove}
+        onTouchEnd={handleTouchEnd}
+        onTouchCancel={handleTouchCancel}
       >
-        <div 
-          className={`relative w-[52px] h-[52px] rounded-xl overflow-hidden shadow-sm cursor-grab active:cursor-grabbing ${
-            showDropBefore
-              ? 'border-l-2 border-blue-500'
-              : showDropAfter
-                ? 'border-r-2 border-blue-500'
-                : isMaskTarget
-                  ? 'border-2 border-blue-500'
-                  : 'border border-gray-200 dark:border-white/[0.08]'
+        <ButtonTooltip
+          visible={imageHintId === img.id && Boolean(imageHintText) && (!isMobile || isMaskTarget)}
+          text={imageHintText}
+        />
+        {showDropBefore && (
+          <div className="absolute -left-[5px] top-0 bottom-0 w-[2px] bg-blue-500 rounded-full z-40 shadow-sm pointer-events-none" />
+        )}
+        {showDropAfter && (
+          <div className="absolute -right-[5px] top-0 bottom-0 w-[2px] bg-blue-500 rounded-full z-40 shadow-sm pointer-events-none" />
+        )}
+        <div
+          className={`relative w-[52px] h-[52px] rounded-xl overflow-hidden shadow-sm cursor-grab active:cursor-grabbing select-none ${
+            isMaskTarget
+              ? 'border-2 border-blue-500'
+              : 'border border-gray-200 dark:border-white/[0.08]'
           }`}
-          onClick={() => setLightboxImageId(img.id, inputImages.map((i) => i.id))}
+          onClick={() => {
+            if (suppressImageClickRef.current) return
+            if (isMaskTarget) {
+              setMaskEditorImageId(img.id)
+              return
+            }
+            if (isMobile && maskTargetImage && !maskConflictNoticeShownRef.current) {
+              maskConflictNoticeShownRef.current = true
+              showToast('只能有一张遮罩图', 'info')
+            }
+            setLightboxImageId(img.id, inputImages.map((i) => i.id))
+          }}
         >
           <img
             src={displaySrc}
@@ -577,17 +766,19 @@ export default function InputBar() {
             </button>
           )}
         </div>
-        <span
-          className="absolute -top-2 -right-2 w-[22px] h-[22px] rounded-full bg-red-500 text-white flex items-center justify-center cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity shadow-md hover:bg-red-600 z-30"
-          onClick={(e) => {
-            e.stopPropagation()
-            removeInputImage(idx)
-          }}
-        >
-          <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-          </svg>
-        </span>
+        {!isMaskTarget && (
+          <span
+            className="absolute -top-2 -right-2 w-[22px] h-[22px] rounded-full bg-red-500 text-white flex items-center justify-center cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity shadow-md hover:bg-red-600 z-30"
+            onClick={(e) => {
+              e.stopPropagation()
+              removeInputImage(idx)
+            }}
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </span>
+        )}
       </div>
     )
   }
@@ -620,6 +811,15 @@ export default function InputBar() {
           {inputImages.map((img, idx) => renderImageThumb(img, idx))}
           {renderClearAllButton()}
         </div>
+        {touchDragPreview && createPortal(
+          <div
+            className="fixed z-[140] h-[52px] w-[52px] overflow-hidden rounded-xl shadow-xl pointer-events-none opacity-90"
+            style={{ left: touchDragPreview.x, top: touchDragPreview.y, transform: 'translate(-50%, -50%)' }}
+          >
+            <img src={touchDragPreview.src} className="h-full w-full object-cover" alt="" />
+          </div>,
+          document.body,
+        )}
       </div>
     )
   }

--- a/src/components/MaskEditorModal.tsx
+++ b/src/components/MaskEditorModal.tsx
@@ -839,7 +839,7 @@ export default function MaskEditorModal() {
 
   return (
     <>
-      <div className="fixed inset-0 z-[80] flex flex-col bg-gray-50 dark:bg-gray-900 animate-modal-in">
+      <div data-no-drag-select className="fixed inset-0 z-[80] flex flex-col bg-gray-50 dark:bg-gray-900 animate-modal-in">
       {/* Header */}
       <div className="flex-none flex items-center justify-between px-4 py-3 border-b border-gray-200 bg-white dark:border-gray-800 dark:bg-gray-950 z-20">
         <div className="flex items-center gap-3">

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -10,7 +10,7 @@ export default function SearchBar() {
   const setFilterFavorite = useStore((s) => s.setFilterFavorite)
 
   return (
-    <div className="mt-6 mb-4 flex gap-3">
+    <div data-no-drag-select className="mt-6 mb-4 flex gap-3">
       <div className="flex gap-2 flex-shrink-0 z-20">
         <button
           onClick={() => setFilterFavorite(!filterFavorite)}

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -72,7 +72,7 @@ export default function SettingsModal() {
   }
 
   return (
-    <div className="fixed inset-0 z-[70] flex items-center justify-center p-4">
+    <div data-no-drag-select className="fixed inset-0 z-[70] flex items-center justify-center p-4">
       <div
         className="absolute inset-0 bg-black/30 backdrop-blur-sm animate-overlay-in"
         onClick={handleClose}
@@ -139,7 +139,7 @@ export default function SettingsModal() {
                   placeholder={DEFAULT_SETTINGS.baseUrl}
                   className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                 />
-                <div className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
+                <div data-selectable-text className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
                   支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiUrl=</code>，<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">codexCli=true</code>
                 </div>
               </label>
@@ -176,7 +176,7 @@ export default function SettingsModal() {
                     )}
                   </button>
                 </div>
-                <div className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
+                <div data-selectable-text className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
                   支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiKey=</code>
                 </div>
               </div>
@@ -201,7 +201,7 @@ export default function SettingsModal() {
                   ]}
                   className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                 />
-                <div className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
+                <div data-selectable-text className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
                   支持通过查询参数覆盖：<code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">apiMode=images</code> 或 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">apiMode=responses</code>。
                 </div>
               </label>
@@ -218,7 +218,7 @@ export default function SettingsModal() {
                   placeholder={getDefaultModelForMode(draft.apiMode ?? DEFAULT_SETTINGS.apiMode)}
                   className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                 />
-                <div className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
+                <div data-selectable-text className="mt-1 text-[10px] text-gray-400 dark:text-gray-500">
                   {(draft.apiMode ?? DEFAULT_SETTINGS.apiMode) === 'responses' ? (
                     <>Responses API 需要使用支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code> 工具的文本模型，例如 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_RESPONSES_MODEL}</code>。</>
                   ) : (

--- a/src/components/SizePickerModal.tsx
+++ b/src/components/SizePickerModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { calculateImageSize, normalizeImageSize, parseRatio, type SizeTier } from '../lib/size'
+import ViewportTooltip from './ViewportTooltip'
 
 const TIERS: SizeTier[] = ['1K', '2K', '4K']
 const SIZE_LIMIT_TEXT = '由于模型限制，最终输出会自动规整到合法尺寸：宽高均为 16 的倍数，最大边长 3840px，宽高比不超过 3:1，总像素限制为 655360-8294400。'
@@ -139,7 +140,7 @@ export default function SizePickerModal({ currentSize, onSelect, onClose }: Prop
   }
 
   return (
-    <div className="fixed inset-0 z-[70] flex items-center justify-center p-4" onClick={onClose}>
+    <div data-no-drag-select className="fixed inset-0 z-[70] flex items-center justify-center p-4" onClick={onClose}>
       <div className="absolute inset-0 bg-black/30 backdrop-blur-sm animate-overlay-in" />
       <div
         className="relative z-10 w-full max-w-md rounded-3xl border border-white/50 bg-white/95 p-5 shadow-2xl ring-1 ring-black/5 animate-modal-in dark:border-white/[0.08] dark:bg-gray-900/95 dark:ring-white/10"
@@ -306,12 +307,9 @@ export default function SizePickerModal({ currentSize, onSelect, onClose }: Prop
                   <svg className="w-5 h-5 text-yellow-500 cursor-pointer" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                   </svg>
-                  {hintVisible && (
-                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 z-20 w-56 bg-gray-800 text-white text-xs rounded-lg px-3 py-2 shadow-lg whitespace-normal text-center pointer-events-none">
-                      {SIZE_LIMIT_TEXT}
-                      <div className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800" />
-                    </div>
-                  )}
+                  <ViewportTooltip visible={hintVisible} className="w-56 whitespace-normal text-center">
+                    {SIZE_LIMIT_TEXT}
+                  </ViewportTooltip>
                 </div>
               )}
             </div>

--- a/src/components/TaskGrid.tsx
+++ b/src/components/TaskGrid.tsx
@@ -12,10 +12,6 @@ export default function TaskGrid() {
   const selectedTaskIds = useStore((s) => s.selectedTaskIds)
   const setSelectedTaskIds = useStore((s) => s.setSelectedTaskIds)
   const clearSelection = useStore((s) => s.clearSelection)
-  const hasOverlayOpen = useStore((s) =>
-    Boolean(s.detailTaskId || s.lightboxImageId || s.maskEditorImageId || s.showSettings || s.confirmDialog),
-  )
-
   const rootRef = useRef<HTMLDivElement>(null)
   const gridRef = useRef<HTMLDivElement>(null)
   const [selectionBox, setSelectionBox] = useState<{ startX: number; startY: number; currentX: number; currentY: number } | null>(null)
@@ -106,18 +102,23 @@ export default function TaskGrid() {
   }
 
   useEffect(() => {
+    const getEventElement = (e: MouseEvent) => {
+      if (e.target instanceof Element) return e.target
+      return document.elementFromPoint(e.clientX, e.clientY)
+    }
+
     const handleDocumentMouseDown = (e: MouseEvent) => {
-      if (hasOverlayOpen) return
       if (e.button !== 0) return
-      const target = e.target as HTMLElement | null
+      const target = getEventElement(e)
       if (!target) return
-      if (!target.closest('[data-home-main]')) return
+      if (!target.closest('[data-drag-select-surface]')) return
       if (target.closest('[data-input-bar]')) return
-      if (target.closest('[data-no-drag-select]')) return
+      if (target.closest('[data-no-drag-select], [data-lightbox-root]')) return
       if (target.closest('button, a, input, textarea, select')) return
 
       const isCtrl = isMac ? e.metaKey : e.ctrlKey
-      beginSelection(target, e.clientX, e.clientY, isCtrl)
+      beginSelection(target as HTMLElement, e.clientX, e.clientY, isCtrl)
+      e.preventDefault()
     }
 
     const handleDocumentMouseMove = (e: MouseEvent) => {
@@ -154,15 +155,15 @@ export default function TaskGrid() {
       setSelectionBox(null)
     }
 
-    document.addEventListener('mousedown', handleDocumentMouseDown)
-    document.addEventListener('mousemove', handleDocumentMouseMove)
-    document.addEventListener('mouseup', handleDocumentMouseUp)
+    document.addEventListener('mousedown', handleDocumentMouseDown, true)
+    document.addEventListener('mousemove', handleDocumentMouseMove, true)
+    document.addEventListener('mouseup', handleDocumentMouseUp, true)
     return () => {
-      document.removeEventListener('mousedown', handleDocumentMouseDown)
-      document.removeEventListener('mousemove', handleDocumentMouseMove)
-      document.removeEventListener('mouseup', handleDocumentMouseUp)
+      document.removeEventListener('mousedown', handleDocumentMouseDown, true)
+      document.removeEventListener('mousemove', handleDocumentMouseMove, true)
+      document.removeEventListener('mouseup', handleDocumentMouseUp, true)
     }
-  }, [clearSelection, hasOverlayOpen, isMac])
+  }, [clearSelection, isMac])
 
   if (!filteredTasks.length) {
     return (
@@ -228,7 +229,7 @@ export default function TaskGrid() {
       </div>
       {selectionBox && (
         <div
-          className="fixed bg-blue-500/20 border border-blue-500/50 pointer-events-none z-[100]"
+          className="fixed bg-blue-500/20 border border-blue-500/50 pointer-events-none z-[30]"
           style={{
             left: Math.min(selectionBox.startX, selectionBox.currentX),
             top: Math.min(selectionBox.startY, selectionBox.currentY),

--- a/src/components/ViewportTooltip.tsx
+++ b/src/components/ViewportTooltip.tsx
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+
+interface ViewportTooltipProps {
+  visible: boolean
+  children: ReactNode
+  className?: string
+}
+
+export default function ViewportTooltip({ visible, children, className = '' }: ViewportTooltipProps) {
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const [offsetX, setOffsetX] = useState(0)
+
+  useEffect(() => {
+    if (!visible) {
+      setOffsetX(0)
+      return
+    }
+
+    const updatePosition = () => {
+      const el = tooltipRef.current
+      if (!el) return
+      const margin = 8
+      const rect = el.getBoundingClientRect()
+      if (rect.left < margin) {
+        setOffsetX(margin - rect.left)
+      } else if (rect.right > window.innerWidth - margin) {
+        setOffsetX(window.innerWidth - margin - rect.right)
+      } else {
+        setOffsetX(0)
+      }
+    }
+
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    return () => window.removeEventListener('resize', updatePosition)
+  }, [visible, children])
+
+  if (!visible) return null
+
+  return (
+    <div
+      ref={tooltipRef}
+      className={`absolute bottom-full left-1/2 mb-2 pointer-events-none z-20 rounded-lg bg-gray-800 px-3 py-2 text-xs font-normal text-white shadow-lg ${className}`}
+      style={{ transform: `translateX(calc(-50% + ${offsetX}px))` }}
+    >
+      {children}
+      <div
+        className="absolute top-full left-1/2 -translate-x-1/2 border-4 border-transparent border-t-gray-800"
+        style={{ marginLeft: -offsetX }}
+      />
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -21,6 +21,20 @@ html {
 
 body {
   padding: 0;
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+
+input,
+textarea,
+select,
+[contenteditable="true"],
+[data-selectable-text],
+[data-selectable-text] * {
+  -webkit-user-select: text;
+  user-select: text;
+  -webkit-touch-callout: default;
 }
 
 * {
@@ -30,6 +44,9 @@ body {
 
 img {
   -webkit-user-drag: none;
+  user-select: none;
+  -webkit-user-select: none;
+  -webkit-touch-callout: none;
 }
 
 body.drag-selecting,

--- a/src/lib/paramDisplay.tsx
+++ b/src/lib/paramDisplay.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import type { TaskParams, TaskRecord } from '../types'
+import ViewportTooltip from '../components/ViewportTooltip'
 
 type ParamKey = keyof TaskParams
 
@@ -55,12 +56,9 @@ export function ActualValueBadge({ value, className = '', variant = 'highlight' 
       onTouchCancel={clearTouchTimer}
     >
       {value}
-      {tooltipVisible && (
-        <span className="absolute bottom-full left-1/2 z-20 mb-2 -translate-x-1/2 whitespace-nowrap rounded-lg bg-gray-800 px-3 py-2 text-xs font-normal text-white shadow-lg pointer-events-none">
-          API 实际响应值
-          <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-gray-800" />
-        </span>
-      )}
+      <ViewportTooltip visible={tooltipVisible} className="whitespace-nowrap">
+        API 实际响应值
+      </ViewportTooltip>
     </span>
   )
 }

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -44,19 +44,20 @@ describe('mask draft lifecycle in store actions', () => {
     })
   })
 
-  it('clears an existing mask when quick edit-output adds outputs as references', async () => {
+  it('preserves an existing mask when quick edit-output adds outputs as references', async () => {
+    const maskDraft = {
+      targetImageId: imageA.id,
+      maskDataUrl: 'data:image/png;base64,mask',
+      updatedAt: 1,
+    }
     useStore.setState({
       inputImages: [imageA],
-      maskDraft: {
-        targetImageId: imageA.id,
-        maskDataUrl: 'data:image/png;base64,mask',
-        updatedAt: 1,
-      },
+      maskDraft,
     })
 
     await editOutputs(task({ outputImages: [imageA.id] }))
 
-    expect(useStore.getState().maskDraft).toBeNull()
+    expect(useStore.getState().maskDraft).toEqual(maskDraft)
   })
 
   it('clears an invalid mask draft when submit cannot find the mask target image', async () => {

--- a/src/store.ts
+++ b/src/store.ts
@@ -64,6 +64,7 @@ interface AppState {
   removeInputImage: (idx: number) => void
   clearInputImages: () => void
   setInputImages: (imgs: InputImage[]) => void
+  moveInputImage: (fromIdx: number, toIdx: number) => void
   maskDraft: MaskDraft | null
   setMaskDraft: (draft: MaskDraft | null) => void
   clearMaskDraft: () => void
@@ -172,6 +173,13 @@ export const useStore = create<AppState>()(
             inputImages: imgs,
             ...(shouldClearMask ? { maskDraft: null, maskEditorImageId: null } : {}),
           }
+        }),
+      moveInputImage: (fromIdx, toIdx) =>
+        set((s) => {
+          const images = [...s.inputImages]
+          const [moved] = images.splice(fromIdx, 1)
+          images.splice(toIdx, 0, moved)
+          return { inputImages: images }
         }),
       maskDraft: null,
       setMaskDraft: (maskDraft) => set({ maskDraft }),

--- a/src/store.ts
+++ b/src/store.ts
@@ -47,6 +47,16 @@ export async function ensureImageCached(id: string): Promise<string | undefined>
   return undefined
 }
 
+function orderImagesWithMaskFirst(images: InputImage[], maskTargetImageId: string | null | undefined) {
+  if (!maskTargetImageId) return images
+  const maskIdx = images.findIndex((img) => img.id === maskTargetImageId)
+  if (maskIdx <= 0) return images
+  const next = [...images]
+  const [maskImage] = next.splice(maskIdx, 1)
+  next.unshift(maskImage)
+  return next
+}
+
 // ===== Store 类型 =====
 
 interface AppState {
@@ -167,22 +177,34 @@ export const useStore = create<AppState>()(
         }),
       setInputImages: (imgs) =>
         set((s) => {
+          const inputImages = orderImagesWithMaskFirst(imgs, s.maskDraft?.targetImageId)
           const shouldClearMask =
-            Boolean(s.maskDraft) && !imgs.some((img) => img.id === s.maskDraft?.targetImageId)
+            Boolean(s.maskDraft) && !inputImages.some((img) => img.id === s.maskDraft?.targetImageId)
           return {
-            inputImages: imgs,
+            inputImages,
             ...(shouldClearMask ? { maskDraft: null, maskEditorImageId: null } : {}),
           }
         }),
       moveInputImage: (fromIdx, toIdx) =>
         set((s) => {
           const images = [...s.inputImages]
+          if (fromIdx < 0 || fromIdx >= images.length) return s
+          const maskTargetImageId = s.maskDraft?.targetImageId
+          if (maskTargetImageId && images[fromIdx]?.id === maskTargetImageId) return s
+          const minTargetIdx = maskTargetImageId && images.some((img) => img.id === maskTargetImageId) ? 1 : 0
+          const targetIdx = Math.max(minTargetIdx, Math.min(images.length, toIdx))
+          const insertIdx = fromIdx < targetIdx ? targetIdx - 1 : targetIdx
+          if (insertIdx === fromIdx) return s
           const [moved] = images.splice(fromIdx, 1)
-          images.splice(toIdx, 0, moved)
+          images.splice(insertIdx, 0, moved)
           return { inputImages: images }
         }),
       maskDraft: null,
-      setMaskDraft: (maskDraft) => set({ maskDraft }),
+      setMaskDraft: (maskDraft) =>
+        set((s) => ({
+          maskDraft,
+          inputImages: orderImagesWithMaskFirst(s.inputImages, maskDraft?.targetImageId),
+        })),
       clearMaskDraft: () => set({ maskDraft: null }),
       maskEditorImageId: null,
       setMaskEditorImageId: (maskEditorImageId) => set({ maskEditorImageId }),
@@ -532,10 +554,9 @@ export async function reuseConfig(task: TaskRecord) {
 
 /** 编辑输出：将输出图加入输入 */
 export async function editOutputs(task: TaskRecord) {
-  const { inputImages, addInputImage, clearMaskDraft, showToast } = useStore.getState()
+  const { inputImages, addInputImage, showToast } = useStore.getState()
   if (!task.outputImages?.length) return
 
-  clearMaskDraft()
   let added = 0
   for (const imgId of task.outputImages) {
     if (inputImages.find((i) => i.id === imgId)) continue


### PR DESCRIPTION
在输入栏参考图缩略图上新增拖拽排序功能，可拖拽调整参考图的输入顺序。

有时需要控制多张参考图的先后顺序（例如第一张作为主参考、后续为辅），但之前只能通过逐个删除再按顺序重新添加来实现，操作繁琐。

实现
- src/store.ts: 新增 moveInputImage(fromIdx, toIdx) action，通过 splice 实现数组内图片换位
- src/components/InputBar.tsx: 使用原生 HTML5 Drag & Drop，零依赖