### PR TITLE
fix: preserve API mode across page reloads

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,10 +20,7 @@ export default function App() {
 
   useEffect(() => {
     const searchParams = new URLSearchParams(window.location.search)
-    const nextSettings: { baseUrl?: string; apiKey?: string; codexCli?: boolean; apiMode?: ApiMode } = {
-      codexCli: false,
-      apiMode: 'images',
-    }
+    const nextSettings: { baseUrl?: string; apiKey?: string; codexCli?: boolean; apiMode?: ApiMode } = {}
 
     const apiUrlParam = searchParams.get('apiUrl')
     if (apiUrlParam !== null) {


### PR DESCRIPTION
Avoid defaulting apiMode and codexCli during app initialization, so persisted settings are not overwritten unless explicitly provided via URL query params.

Close https://github.com/CookSleep/gpt_image_playground/issues/15