### PR TITLE
fix: allow iOS long-press on generated images

### DIFF
--- a/src/components/DetailModal.tsx
+++ b/src/components/DetailModal.tsx
@@ -290,7 +290,7 @@ export default function DetailModal() {
               <img
                 ref={mainImageRef}
                 src={currentOutputImageSrc}
-                className="max-w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] object-contain cursor-pointer"
+                className="saveable-image max-w-[calc(100%-2rem)] max-h-[calc(100%-2rem)] object-contain cursor-pointer"
                 onLoad={() => {
                   const panel = imagePanelRef.current
                   const image = mainImageRef.current

--- a/src/components/ImageContextMenu.tsx
+++ b/src/components/ImageContextMenu.tsx
@@ -21,6 +21,11 @@ export default function ImageContextMenu() {
         // 忽略没有 src 或空的 img
         if (!imgTarget.src) return
 
+        // iOS 触控设备上，放行原生长按菜单（以支持原生保存图片）
+        const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) || (navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 1)
+        const isTouch = window.matchMedia('(pointer: coarse)').matches
+        if (isIOS && isTouch) return
+
         e.preventDefault()
         setMenuInfo({
           src: imgTarget.src,

--- a/src/components/Lightbox.tsx
+++ b/src/components/Lightbox.tsx
@@ -461,7 +461,7 @@ function LightboxInner({ src, maskPreviewSrc, onClose, showNav, currentIndex, to
         >
           <img
             src={src}
-            className="max-w-[85vw] max-h-[85vh] object-contain rounded-lg shadow-2xl"
+            className="saveable-image max-w-[85vw] max-h-[85vh] object-contain rounded-lg shadow-2xl"
             onDragStart={(e) => e.preventDefault()}
             alt=""
           />

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -275,7 +275,7 @@ export default function TaskCard({
             <>
               <img
                 src={thumbSrc}
-                className="w-full h-full object-cover"
+                className="saveable-image w-full h-full object-cover"
                 loading="lazy"
                 alt=""
               />

--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,6 @@ body {
   padding: 0;
   -webkit-user-select: none;
   user-select: none;
-  -webkit-touch-callout: none;
 }
 
 input,
@@ -46,7 +45,12 @@ img {
   -webkit-user-drag: none;
   user-select: none;
   -webkit-user-select: none;
-  -webkit-touch-callout: none;
+}
+
+.saveable-image {
+  -webkit-touch-callout: default;
+  -webkit-user-select: auto;
+  user-select: auto;
 }
 
 body.drag-selecting,


### PR DESCRIPTION
## 说明

修复 #22 中提到的 iOS Edge / Edge PWA 长按生成图片无法保存的问题。

原因是当前全局样式对 `body` 和 `img` 设置了 `-webkit-touch-callout: none`，在 iOS WebKit 上会禁用原生长按菜单。Safari 里可能表现比较宽松，但 Edge iOS / PWA 会更容易受影响。

## 修改

- 移除 `body` / 全局 `img` 上的 `-webkit-touch-callout: none`
- 新增 `.saveable-image`，显式恢复生成图片的原生长按行为
- 给生成图缩略图、详情页大图、Lightbox 大图加上 `.saveable-image`

我这边已经在 iOS Edge / Edge PWA 上测试，长按保存图片恢复正常。

## 验证

- `npm test`
- `npm run build`