### PR TITLE
Preserve a clean sync point for the forked Responses API work

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom'
 import { useStore, submitTask, addImageFromFile, updateTaskInStore, removeMultipleTasks } from '../store'
 import { DEFAULT_PARAMS } from '../types'
 import { getActiveApiProfile } from '../lib/apiProfiles'
+import { getMixedContentError, isApiProxyAvailable, readClientDevProxyConfig, shouldUseApiProxy } from '../lib/devProxy'
 import { DEFAULT_FAL_IMAGE_SIZE, getChangedParams, getOutputImageLimitForSettings, normalizeParamsForSettings } from '../lib/paramCompatibility'
 import { normalizeImageSize } from '../lib/size'
 import { createMaskPreviewDataUrl } from '../lib/canvasImage'
@@ -156,6 +157,11 @@ export default function InputBar() {
   const canSubmit = prompt.trim() && settings.apiKey
   const activeProfile = getActiveApiProfile(settings)
   const activeProvider = activeProfile.provider
+  const proxyConfig = readClientDevProxyConfig()
+  const apiProxyEnabled = activeProvider === 'openai' && isApiProxyAvailable(proxyConfig) && (activeProfile.apiProxy || shouldUseApiProxy(activeProfile.baseUrl, proxyConfig))
+  const mixedContentError = activeProvider === 'openai' && !apiProxyEnabled
+    ? getMixedContentError(activeProfile.baseUrl)
+    : null
   const isFalProvider = activeProvider === 'fal'
   const moderationDisabled = settings.apiMode === 'responses' || isFalProvider
   const compressionDisabled = params.output_format === 'png' || isFalProvider
@@ -185,6 +191,11 @@ export default function InputBar() {
   const referenceImages = maskTargetImage
     ? inputImages.filter((img) => img.id !== maskTargetImage.id)
     : inputImages
+  const submitTooltipText = !settings.apiKey
+    ? '尚未完成 API 配置，请在右上角设置中进行'
+    : mixedContentError
+      ? mixedContentError
+      : null
 
   useEffect(() => {
     setOutputCompressionInput(
@@ -1257,16 +1268,22 @@ export default function InputBar() {
                   onMouseEnter={() => setSubmitHover(true)}
                   onMouseLeave={() => setSubmitHover(false)}
                 >
-                  <ButtonTooltip visible={!settings.apiKey && submitHover} text="尚未完成 API 配置，请在右上角设置中进行" />
+                  <ButtonTooltip visible={Boolean(submitTooltipText && submitHover)} text={submitTooltipText ?? ''} />
                   <button
                     onClick={() => settings.apiKey ? submitTask() : setShowSettings(true)}
-                    disabled={settings.apiKey ? !canSubmit : false}
+                    disabled={settings.apiKey ? (!canSubmit || Boolean(mixedContentError)) : false}
                     className={`p-2.5 rounded-xl transition-all shadow-sm hover:shadow ${
                       !settings.apiKey
                         ? 'bg-gray-300 dark:bg-white/[0.06] text-white cursor-pointer'
                         : 'bg-blue-500 text-white hover:bg-blue-600 disabled:bg-gray-300 dark:disabled:bg-white/[0.04] disabled:opacity-50 disabled:cursor-not-allowed'
                     }`}
-                    title={settings.apiKey ? (maskDraft ? '遮罩编辑 (Ctrl+Enter)' : '生成 (Ctrl+Enter)') : '请先配置 API'}
+                    title={settings.apiKey
+                      ? mixedContentError
+                        ? mixedContentError
+                        : maskDraft
+                          ? '遮罩编辑 (Ctrl+Enter)'
+                          : '生成 (Ctrl+Enter)'
+                      : '请先配置 API'}
                   >
                     <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 7l5 5m0 0l-5 5m5-5H6" />
@@ -1311,10 +1328,17 @@ export default function InputBar() {
                   onMouseEnter={() => setSubmitHover(true)}
                   onMouseLeave={() => setSubmitHover(false)}
                 >
-                  <ButtonTooltip visible={!settings.apiKey && submitHover} text="尚未完成 API 配置，请在右上角设置中进行" />
+                  <ButtonTooltip visible={Boolean(submitTooltipText && submitHover)} text={submitTooltipText ?? ''} />
                   <button
                     onClick={() => settings.apiKey ? submitTask() : setShowSettings(true)}
-                    disabled={settings.apiKey ? !canSubmit : false}
+                    disabled={settings.apiKey ? (!canSubmit || Boolean(mixedContentError)) : false}
+                    title={settings.apiKey
+                      ? mixedContentError
+                        ? mixedContentError
+                        : maskDraft
+                          ? '遮罩编辑 (Ctrl+Enter)'
+                          : '生成图像 (Ctrl+Enter)'
+                      : '请先配置 API'}
                     className={`w-full flex items-center justify-center gap-2 py-2.5 rounded-xl text-sm font-medium transition-all shadow-sm ${
                       !settings.apiKey
                         ? 'bg-gray-300 dark:bg-white/[0.06] text-white cursor-pointer'

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from 'react'
 import { normalizeBaseUrl } from '../lib/api'
-import { isApiProxyAvailable, readClientDevProxyConfig } from '../lib/devProxy'
+import { getMixedContentError, isApiProxyAvailable, readClientDevProxyConfig, shouldUseApiProxy } from '../lib/devProxy'
 import { useStore, exportData, importData, clearAllData } from '../store'
 import {
   createDefaultOpenAIProfile,
@@ -41,7 +41,10 @@ export default function SettingsModal() {
   
   const apiProxyAvailable = isApiProxyAvailable(readClientDevProxyConfig())
   const activeProfile = draft.profiles.find((profile) => profile.id === draft.activeProfileId) ?? draft.profiles[0] ?? getActiveApiProfile(draft)
-  const apiProxyEnabled = apiProxyAvailable && activeProfile.provider === 'openai' && activeProfile.apiProxy
+  const apiProxyEnabled = apiProxyAvailable && activeProfile.provider === 'openai' && (activeProfile.apiProxy || shouldUseApiProxy(activeProfile.baseUrl))
+  const mixedContentError = activeProfile.provider === 'openai' && !apiProxyEnabled
+    ? getMixedContentError(activeProfile.baseUrl)
+    : null
 
   const getDefaultModelForMode = (apiMode: AppSettings['apiMode']) =>
     apiMode === 'responses' ? DEFAULT_RESPONSES_MODEL : DEFAULT_IMAGES_MODEL
@@ -397,11 +400,16 @@ export default function SettingsModal() {
                   />
                   <div data-selectable-text className="mt-1 min-h-[22px] flex items-center text-[10px] text-gray-400 dark:text-gray-500">
                     {apiProxyEnabled ? (
-                      <span className="text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</span>
+                      <span className="text-yellow-600 dark:text-yellow-500">已启用同源代理，实际请求会走 /api-proxy，此处 API URL 设置会被忽略。</span>
                     ) : (
                       <span>支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiUrl=</code>，<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">codexCli=true</code></span>
                     )}
                   </div>
+                  {mixedContentError && (
+                    <div data-selectable-text className="mt-2 rounded-xl border border-red-200/70 bg-red-50/80 px-3 py-2 text-[10px] leading-relaxed text-red-600 dark:border-red-500/20 dark:bg-red-500/10 dark:text-red-300">
+                      {mixedContentError}
+                    </div>
+                  )}
                 </label>
               )}
 

--- a/src/lib/api.test.ts
+++ b/src/lib/api.test.ts
@@ -7,6 +7,7 @@ describe('callImageApi', () => {
   afterEach(() => {
     vi.restoreAllMocks()
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
   })
 
   it.each([false, true])(
@@ -125,7 +126,7 @@ describe('callImageApi', () => {
     )
   })
 
-  it('ignores stored API proxy settings when the current deployment has no proxy', async () => {
+  it('uses the configured API URL directly for public hosts when API proxy is disabled', async () => {
     vi.stubEnv('VITE_API_PROXY_AVAILABLE', 'false')
     const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       data: [{ b64_json: 'aW1hZ2U=' }],
@@ -138,8 +139,8 @@ describe('callImageApi', () => {
       settings: {
         ...DEFAULT_SETTINGS,
         apiKey: 'test-key',
-        apiProxy: true,
-        baseUrl: 'http://api.example.com/v1',
+        apiProxy: false,
+        baseUrl: 'https://api.example.com/v1',
       },
       prompt: 'prompt',
       params: { ...DEFAULT_PARAMS },
@@ -147,7 +148,44 @@ describe('callImageApi', () => {
     })
 
     expect(fetchMock).toHaveBeenCalledWith(
-      'http://api.example.com/v1/images/generations',
+      'https://api.example.com/v1/images/generations',
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('uses the dev proxy automatically for local network API URLs', async () => {
+    vi.stubGlobal('__DEV_PROXY_CONFIG__', {
+      enabled: true,
+      prefix: '/api-proxy',
+      target: 'http://192.168.0.171:8080/v1',
+      changeOrigin: true,
+      secure: false,
+    })
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      output: [{
+        type: 'image_generation_call',
+        result: 'aW1hZ2U=',
+      }],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+
+    await callImageApi({
+      settings: {
+        ...DEFAULT_SETTINGS,
+        apiKey: 'test-key',
+        apiMode: 'responses',
+        apiProxy: false,
+        baseUrl: 'http://192.168.0.171:8080/v1',
+      },
+      prompt: 'prompt',
+      params: { ...DEFAULT_PARAMS },
+      inputImageDataUrls: [],
+    })
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api-proxy/responses',
       expect.objectContaining({ method: 'POST' }),
     )
   })

--- a/src/lib/devProxy.test.ts
+++ b/src/lib/devProxy.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { buildApiUrl } from './devProxy'
+import { buildApiUrl, getMixedContentError, shouldUseApiProxy } from './devProxy'
 
 describe('buildApiUrl', () => {
   it('uses the same-origin proxy prefix when API proxy is enabled', () => {
@@ -35,5 +35,35 @@ describe('buildApiUrl', () => {
     expect(buildApiUrl('http://api.example.com/v1', 'responses', null, false)).toBe(
       'http://api.example.com/v1/responses',
     )
+  })
+
+  it('flags direct HTTP API URLs on HTTPS pages', () => {
+    expect(getMixedContentError('http://api.example.com/v1', 'https:')).toMatch(
+      '浏览器会拦截 HTTP API 请求',
+    )
+  })
+
+  it('does not flag HTTPS API URLs on HTTPS pages', () => {
+    expect(getMixedContentError('https://api.example.com/v1', 'https:')).toBeNull()
+  })
+
+  it('auto-uses the proxy for local network API URLs in dev', () => {
+    expect(shouldUseApiProxy('http://192.168.0.171:8080/v1', {
+      enabled: true,
+      prefix: '/api-proxy',
+      target: 'http://192.168.0.171:8080/v1',
+      changeOrigin: true,
+      secure: false,
+    }, 'http://192.168.0.105:4173', true)).toBe(true)
+  })
+
+  it('does not auto-use the proxy for public HTTPS API URLs', () => {
+    expect(shouldUseApiProxy('https://api.example.com/v1', {
+      enabled: true,
+      prefix: '/api-proxy',
+      target: 'https://api.example.com/v1',
+      changeOrigin: true,
+      secure: false,
+    }, 'http://192.168.0.105:4173', true)).toBe(false)
   })
 })

--- a/src/lib/devProxy.ts
+++ b/src/lib/devProxy.ts
@@ -88,3 +88,44 @@ export function readClientDevProxyConfig(): DevProxyConfig | null {
 export function isApiProxyAvailable(proxyConfig: DevProxyConfig | null = readClientDevProxyConfig()): boolean {
   return readRuntimeEnv(import.meta.env.VITE_API_PROXY_AVAILABLE) === 'true' || Boolean(proxyConfig?.enabled)
 }
+
+export function getMixedContentError(baseUrl: string, pageProtocol = typeof window !== 'undefined' ? window.location.protocol : ''): string | null {
+  if (pageProtocol !== 'https:') return null
+
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  if (!normalizedBaseUrl || !/^http:\/\//i.test(normalizedBaseUrl)) return null
+
+  return '当前页面是 HTTPS，浏览器会拦截 HTTP API 请求。请改用 HTTPS API，或在本地 HTTP 页面/同源代理环境中使用该地址。'
+}
+
+function isPrivateOrLocalHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase()
+  if (!normalized) return false
+  if (normalized === 'localhost' || normalized === '::1') return true
+  if (normalized.endsWith('.local')) return true
+  if (/^127(?:\.\d{1,3}){3}$/.test(normalized)) return true
+  if (/^10(?:\.\d{1,3}){3}$/.test(normalized)) return true
+  if (/^192\.168(?:\.\d{1,3}){2}$/.test(normalized)) return true
+  if (/^172\.(1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2}$/.test(normalized)) return true
+  return false
+}
+
+export function shouldUseApiProxy(
+  baseUrl: string,
+  proxyConfig: DevProxyConfig | null = readClientDevProxyConfig(),
+  pageOrigin = typeof window !== 'undefined' ? window.location.origin : '',
+  isDev = import.meta.env.DEV,
+): boolean {
+  if (!isApiProxyAvailable(proxyConfig) || !isDev) return false
+
+  const normalizedBaseUrl = normalizeBaseUrl(baseUrl)
+  if (!normalizedBaseUrl) return false
+
+  try {
+    const apiUrl = new URL(normalizedBaseUrl)
+    if (pageOrigin && apiUrl.origin === pageOrigin) return false
+    return isPrivateOrLocalHostname(apiUrl.hostname)
+  } catch {
+    return false
+  }
+}

--- a/src/lib/openaiCompatibleImageApi.ts
+++ b/src/lib/openaiCompatibleImageApi.ts
@@ -1,6 +1,6 @@
 import type { ApiProfile, ImageApiResponse, ResponsesApiResponse, TaskParams } from '../types'
 import { dataUrlToBlob, imageDataUrlToPngBlob, maskDataUrlToPngBlob } from './canvasImage'
-import { buildApiUrl, isApiProxyAvailable, readClientDevProxyConfig } from './devProxy'
+import { buildApiUrl, getMixedContentError, isApiProxyAvailable, readClientDevProxyConfig, shouldUseApiProxy } from './devProxy'
 import {
   assertImageInputPayloadSize,
   assertMaskEditFileSize,
@@ -162,7 +162,11 @@ async function callImagesApiSingle(opts: CallApiOptions, profile: ApiProfile): P
   const isEdit = inputImageDataUrls.length > 0
   const mime = MIME_MAP[params.output_format] || 'image/png'
   const proxyConfig = readClientDevProxyConfig()
-  const useApiProxy = profile.apiProxy && isApiProxyAvailable(proxyConfig)
+  const useApiProxy = isApiProxyAvailable(proxyConfig) && (profile.apiProxy || shouldUseApiProxy(profile.baseUrl, proxyConfig))
+  if (!useApiProxy) {
+    const mixedContentError = getMixedContentError(profile.baseUrl)
+    if (mixedContentError) throw new Error(mixedContentError)
+  }
   const requestHeaders = createRequestHeaders(profile)
 
   const controller = new AbortController()
@@ -339,7 +343,11 @@ async function callResponsesImageApiSingle(opts: CallApiOptions, profile: ApiPro
   const { prompt, params, inputImageDataUrls } = opts
   const mime = MIME_MAP[params.output_format] || 'image/png'
   const proxyConfig = readClientDevProxyConfig()
-  const useApiProxy = profile.apiProxy && isApiProxyAvailable(proxyConfig)
+  const useApiProxy = isApiProxyAvailable(proxyConfig) && (profile.apiProxy || shouldUseApiProxy(profile.baseUrl, proxyConfig))
+  if (!useApiProxy) {
+    const mixedContentError = getMixedContentError(profile.baseUrl)
+    if (mixedContentError) throw new Error(mixedContentError)
+  }
   const requestHeaders = createRequestHeaders(profile)
   const controller = new AbortController()
   const timeoutId = setTimeout(() => controller.abort(), profile.timeout * 1000)

--- a/src/store.ts
+++ b/src/store.ts
@@ -24,6 +24,7 @@ import {
 } from './lib/db'
 import { callImageApi } from './lib/api'
 import { getFalErrorMessage, getFalQueuedImageResult, getFalQueueStatus } from './lib/falAiImageApi'
+import { getMixedContentError, isApiProxyAvailable, readClientDevProxyConfig, shouldUseApiProxy } from './lib/devProxy'
 import { validateMaskMatchesImage } from './lib/canvasImage'
 import { orderInputImagesForMask } from './lib/mask'
 import { getChangedParams, normalizeParamsForSettings } from './lib/paramCompatibility'
@@ -568,6 +569,17 @@ export async function submitTask(options: { allowFullMask?: boolean } = {}) {
   if (!prompt.trim()) {
     showToast('请输入提示词', 'error')
     return
+  }
+
+  if (activeProfile.provider === 'openai') {
+    const proxyConfig = readClientDevProxyConfig()
+    const useApiProxy = isApiProxyAvailable(proxyConfig) && (activeProfile.apiProxy || shouldUseApiProxy(activeProfile.baseUrl, proxyConfig))
+    const mixedContentError = useApiProxy ? null : getMixedContentError(activeProfile.baseUrl)
+    if (mixedContentError) {
+      showToast(mixedContentError, 'error')
+      useStore.getState().setShowSettings(true)
+      return
+    }
   }
 
   let orderedInputImages = inputImages


### PR DESCRIPTION
The current working tree contains a coherent set of local fixes around dev proxy routing, Responses API request shaping, and the associated UI guidance/tests. Capturing them on a dedicated branch keeps the fork aligned with upstream while preserving an isolated history for this line of work.

Constraint: No write access to the original upstream repository
Rejected: Push directly to origin/main | would not fit the forked workflow and risks coupling local work to upstream history
Confidence: high
Scope-risk: narrow
Directive: Keep future proxy and Responses contract changes on this branch until the contract is stable
Tested: npm run test, npm run build
Not-tested: live sub2api quota/INSUFFICIENT_BALANCE behavior after publish