### PR TITLE
feat: 在输入框通过@引用参考的图片（伪全能参考）

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -4,19 +4,71 @@ import { useStore, submitTask, addImageFromFile, updateTaskInStore, removeMultip
 import { DEFAULT_PARAMS } from '../types'
 import { getActiveApiProfile, normalizeSettings } from '../lib/apiProfiles'
 import { DEFAULT_FAL_IMAGE_SIZE, getChangedParams, getOutputImageLimitForSettings, normalizeParamsForSettings } from '../lib/paramCompatibility'
+import { getAtImageQuery, getImageMentionLabel, getPromptMentionParts, imageMentionMatches, insertImageMention } from '../lib/promptImageMentions'
 import { normalizeImageSize } from '../lib/size'
 import { createMaskPreviewDataUrl } from '../lib/canvasImage'
 import { dismissAllTooltips } from '../lib/tooltipDismiss'
+import { getSafeBoundingClientRect } from '../lib/domRect'
 import Select from './Select'
 import SizePickerModal from './SizePickerModal'
 import ViewportTooltip from './ViewportTooltip'
 
+
+/** 获取 contentEditable 中光标的纯文本偏移量 */
+function getContentEditableCursor(el: HTMLElement): number {
+  const sel = window.getSelection()
+  if (!sel || sel.rangeCount === 0) return el.textContent?.length ?? 0
+  try {
+    const range = sel.getRangeAt(0)
+    if (!el.contains(range.startContainer)) return el.textContent?.length ?? 0
+    const preRange = document.createRange()
+    preRange.selectNodeContents(el)
+    preRange.setEnd(range.startContainer, range.startOffset)
+    return preRange.toString().length
+  } catch {
+    return el.textContent?.length ?? 0
+  }
+}
+
+/** 在 contentEditable 中设置光标到指定纯文本偏移量 */
+function setContentEditableCursor(el: HTMLElement, offset: number) {
+  const sel = window.getSelection()
+  if (!sel) return
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT)
+  let remaining = offset
+  let node: Text | null = null
+  while (walker.nextNode()) {
+    node = walker.currentNode as Text
+    if (remaining <= node.length) {
+      const range = document.createRange()
+      range.setStart(node, remaining)
+      range.collapse(true)
+      sel.removeAllRanges()
+      sel.addRange(range)
+      return
+    }
+    remaining -= node.length
+  }
+  // 如果偏移超出，放到末尾
+  if (node) {
+    const range = document.createRange()
+    range.setStart(node, node.length)
+    range.collapse(true)
+    sel.removeAllRanges()
+    sel.addRange(range)
+  }
+}
+
 /** 通用悬浮气泡提示 */
 function ButtonTooltip({ visible, text }: { visible: boolean; text: ReactNode }) {
+  if (!visible) return null
+
   return (
-    <ViewportTooltip visible={visible} className="z-10 whitespace-nowrap">
-      {text}
-    </ViewportTooltip>
+    <span className="absolute left-1/2 top-0 -translate-x-1/2">
+      <ViewportTooltip visible className="z-10 whitespace-nowrap">
+        {text}
+      </ViewportTooltip>
+    </span>
   )
 }
 
@@ -165,7 +217,7 @@ export default function InputBar() {
   const moveInputImage = useStore((s) => s.moveInputImage)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
-  const textareaRef = useRef<HTMLTextAreaElement>(null)
+  const textareaRef = useRef<HTMLDivElement>(null)
   const cardRef = useRef<HTMLDivElement>(null)
   const imagesRef = useRef<HTMLDivElement>(null)
   const prevHeightRef = useRef(42)
@@ -183,6 +235,8 @@ export default function InputBar() {
   const [maskPreviewUrl, setMaskPreviewUrl] = useState('')
   const [imageDragIndex, setImageDragIndex] = useState<number | null>(null)
   const [imageDragOverIndex, setImageDragOverIndex] = useState<number | null>(null)
+  const [atImageMenuIndex, setAtImageMenuIndex] = useState(0)
+  const [atImageMenuDismissed, setAtImageMenuDismissed] = useState(false)
   const [touchDragPreview, setTouchDragPreview] = useState<{ src: string; x: number; y: number } | null>(null)
   const handleRef = useRef<HTMLDivElement>(null)
   const dragTouchRef = useRef({ startY: 0, moved: false })
@@ -191,6 +245,9 @@ export default function InputBar() {
   const imageDragOverIndexRef = useRef<number | null>(null)
   const imageDragPreviewRef = useRef<HTMLElement | null>(null)
   const suppressImageClickRef = useRef(false)
+  const isUserInputRef = useRef(false)
+  const [cursorPos, setCursorPos] = useState(0)
+  const [menuLeft, setMenuLeft] = useState(0)
   const maskConflictNoticeShownRef = useRef(false)
   const compressionHintTimerRef = useRef<number | null>(null)
   const moderationHintTimerRef = useRef<number | null>(null)
@@ -251,6 +308,38 @@ export default function InputBar() {
   const referenceImages = maskTargetImage
     ? inputImages.filter((img) => img.id !== maskTargetImage.id)
     : inputImages
+  const cursorPosition = cursorPos
+  const atImageQuery = getAtImageQuery(prompt, cursorPosition, inputImages)
+  const atImageOptions = atImageQuery
+    ? inputImages
+        .map((img, index) => ({ img, index }))
+        .filter(({ index }) => imageMentionMatches(atImageQuery.query, index))
+    : []
+  const showAtImageMenu = !atImageMenuDismissed && atImageOptions.length > 0
+
+
+
+
+
+  const selectAtImageOption = useCallback((imageIndex: number) => {
+    const el = textareaRef.current
+    const cursor = el ? getContentEditableCursor(el) : prompt.length
+    const query = getAtImageQuery(prompt, cursor, inputImages)
+    setAtImageMenuDismissed(true)
+    setAtImageMenuIndex(0)
+    if (!query) return
+
+    const next = insertImageMention(prompt, query.start, cursor, imageIndex)
+    setPrompt(next.prompt)
+    window.setTimeout(() => {
+      if (textareaRef.current) {
+        textareaRef.current.focus()
+        setContentEditableCursor(textareaRef.current, next.cursor)
+      }
+    }, 0)
+  }, [inputImages, prompt, setPrompt])
+
+
 
   useEffect(() => {
     setOutputCompressionInput(
@@ -537,7 +626,40 @@ export default function InputBar() {
     e.target.value = ''
   }
 
-  const handleKeyDown = (e: React.KeyboardEvent) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (showAtImageMenu) {
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        setAtImageMenuIndex((idx) => (idx + 1) % atImageOptions.length)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        setAtImageMenuIndex((idx) => (idx - 1 + atImageOptions.length) % atImageOptions.length)
+        return
+      }
+      if (e.key === 'Enter' || e.key === 'Tab') {
+        e.preventDefault()
+        selectAtImageOption(atImageOptions[atImageMenuIndex]?.index ?? atImageOptions[0].index)
+        return
+      }
+      if (e.key === 'Escape') {
+        e.preventDefault()
+        setAtImageMenuIndex(0)
+        textareaRef.current?.blur()
+        return
+      }
+    }
+
+    // 阻止 contentEditable 默认换行
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault()
+      if (e.ctrlKey || e.metaKey) {
+        submitTask()
+      }
+      return
+    }
+
     if ((e.ctrlKey || e.metaKey) && e.key === 'Enter') {
       e.preventDefault()
       submitTask()
@@ -650,7 +772,46 @@ export default function InputBar() {
     adjustTextareaHeight()
   }, [prompt, adjustTextareaHeight])
 
-  // 图片队列变化时也重新计算
+  // 将 prompt 同步渲染到 contentEditable（含胶囊 tag）
+  useEffect(() => {
+    const el = textareaRef.current
+    if (!el) return
+    // 用户正在输入时不重新渲染 DOM，避免光标跳动
+    if (isUserInputRef.current) {
+      isUserInputRef.current = false
+      return
+    }
+    const parts = getPromptMentionParts(prompt, inputImages)
+    const html = prompt
+      ? parts.map((part) =>
+          part.type === 'mention'
+            ? `<span contenteditable="false" class="mention-tag">${part.text}</span>`
+            : part.text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+        ).join('')
+      : ''
+    if (el.innerHTML !== html) {
+      el.innerHTML = html
+    }
+  }, [prompt, inputImages])
+
+  // 监听 selectionchange 以在光标移动时更新位置（contentEditable 的 onSelect 不可靠）
+  useEffect(() => {
+    const handleSelectionChange = () => {
+      const el = textareaRef.current
+      if (!el) return
+      const sel = window.getSelection()
+      if (!sel || sel.rangeCount === 0 || !sel.anchorNode) return
+      if (!el.contains(sel.anchorNode)) return
+      setCursorPos(getContentEditableCursor(el))
+      const range = sel.getRangeAt(0)
+      const rangeRect = range.getBoundingClientRect()
+      const elRect = el.getBoundingClientRect()
+      if (rangeRect.width === 0 && rangeRect.height === 0) return
+      setMenuLeft(rangeRect.left - elRect.left)
+    }
+    document.addEventListener('selectionchange', handleSelectionChange)
+    return () => document.removeEventListener('selectionchange', handleSelectionChange)
+  }, [])
   useEffect(() => {
     adjustTextareaHeight()
   }, [inputImages.length, Boolean(maskDraft), maskPreviewUrl, adjustTextareaHeight])
@@ -697,7 +858,8 @@ export default function InputBar() {
     if (!target) return null
     const idx = Number(target.dataset.inputImageIndex)
     if (!Number.isInteger(idx)) return null
-    const rect = target.getBoundingClientRect()
+    const rect = getSafeBoundingClientRect(target)
+    if (!rect) return null
     return touch.clientX < rect.left + rect.width / 2 ? idx : idx + 1
   }
 
@@ -710,7 +872,8 @@ export default function InputBar() {
     if (!maskTargetImage) return false
     const maskEl = document.querySelector<HTMLElement>('[data-input-image-index="0"]')
     if (!maskEl) return false
-    const rect = maskEl.getBoundingClientRect()
+    const rect = getSafeBoundingClientRect(maskEl)
+    if (!rect) return false
     return clientX < rect.left + rect.width / 2
   }
 
@@ -801,7 +964,8 @@ export default function InputBar() {
       e.dataTransfer.dropEffect = 'move'
       const fromIdx = imageDragIndexRef.current
       if (fromIdx === null || fromIdx === idx) return
-      const rect = e.currentTarget.getBoundingClientRect()
+      const rect = getSafeBoundingClientRect(e.currentTarget)
+      if (!rect) return
       setImageDragTarget(e.clientX < rect.left + rect.width / 2 ? idx : idx + 1, e.clientX)
     }
 
@@ -865,7 +1029,7 @@ export default function InputBar() {
       <div
         key={img.id}
         data-input-image-index={idx}
-        className={`relative group inline-block shrink-0 transition-opacity ${isImageDragging ? 'opacity-40' : ''}`}
+        className={`relative group inline-block h-[52px] w-[52px] shrink-0 self-start transition-opacity ${isImageDragging ? 'opacity-40' : ''}`}
         style={{ touchAction: isMaskTarget ? 'auto' : 'none' }}
         draggable={!isMobile && !isMaskTarget}
         onMouseEnter={() => imageHintText && (!isMobile || isMaskTarget) && showImageHint(img.id)}
@@ -878,6 +1042,19 @@ export default function InputBar() {
         onTouchMove={handleTouchMove}
         onTouchEnd={handleTouchEnd}
         onTouchCancel={handleTouchCancel}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          const el = textareaRef.current
+          const cursor = el ? getContentEditableCursor(el) : prompt.length
+          const next = insertImageMention(prompt, cursor, cursor, idx)
+          setPrompt(next.prompt)
+          window.setTimeout(() => {
+            if (textareaRef.current) {
+              textareaRef.current.focus()
+              setContentEditableCursor(textareaRef.current, next.cursor)
+            }
+          }, 0)
+        }}
       >
         <ButtonTooltip
           visible={imageHintId === img.id && Boolean(imageHintText) && (!isMobile || isMaskTarget)}
@@ -890,7 +1067,7 @@ export default function InputBar() {
           <div className="absolute -right-[5px] top-0 bottom-0 w-[2px] bg-blue-500 rounded-full z-40 shadow-sm pointer-events-none" />
         )}
         <div
-          className={`relative w-[52px] h-[52px] rounded-xl overflow-hidden shadow-sm cursor-grab active:cursor-grabbing select-none ${
+          className={`relative w-[52px] h-[52px] rounded-xl shadow-sm cursor-grab active:cursor-grabbing select-none ${
             isMaskTarget
               ? 'border-2 border-blue-500'
               : 'border border-gray-200 dark:border-white/[0.08]'
@@ -909,17 +1086,22 @@ export default function InputBar() {
           }}
         >
           {displaySrc && (
-            <img
-              src={displaySrc}
-              className="w-full h-full object-cover hover:opacity-90 transition-opacity pointer-events-none"
-              alt=""
-            />
+            <div className="h-full w-full overflow-hidden rounded-xl">
+              <img
+                src={displaySrc}
+                className="w-full h-full object-cover hover:opacity-90 transition-opacity pointer-events-none"
+                alt=""
+              />
+            </div>
           )}
           {isMaskTarget && (
             <span className="absolute left-1 top-1 rounded bg-blue-500/90 px-1.5 py-0.5 text-[8px] leading-none text-white font-bold tracking-wider backdrop-blur-sm z-10 pointer-events-none">
               MASK
             </span>
           )}
+          <span className="absolute bottom-1 left-1 rounded bg-black/55 px-1.5 py-0.5 text-[8px] font-semibold leading-none text-white backdrop-blur-sm z-10 pointer-events-none">
+            图{idx + 1}
+          </span>
           {canEdit && (
             <button 
               className="absolute inset-0 w-full h-full bg-black/40 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center cursor-pointer z-20 focus:outline-none border-none"
@@ -934,20 +1116,20 @@ export default function InputBar() {
               </svg>
             </button>
           )}
+          {!isMaskTarget && (
+            <span
+              className="absolute right-0 top-0 flex h-5 w-5 translate-x-1/2 -translate-y-1/2 cursor-pointer items-center justify-center rounded-full bg-red-500 text-white opacity-0 shadow-md transition-opacity hover:bg-red-600 group-hover:opacity-100 z-30"
+              onClick={(e) => {
+                e.stopPropagation()
+                removeInputImage(idx)
+              }}
+            >
+              <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
+              </svg>
+            </span>
+          )}
         </div>
-        {!isMaskTarget && (
-          <span
-            className="absolute -top-2 -right-2 w-[22px] h-[22px] rounded-full bg-red-500 text-white flex items-center justify-center cursor-pointer opacity-0 group-hover:opacity-100 transition-opacity shadow-md hover:bg-red-600 z-30"
-            onClick={(e) => {
-              e.stopPropagation()
-              removeInputImage(idx)
-            }}
-          >
-            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2.5} d="M6 18L18 6M6 6l12 12" />
-            </svg>
-          </span>
-        )}
       </div>
     )
   }
@@ -1291,15 +1473,76 @@ export default function InputBar() {
           )}
 
           {/* 输入框 */}
-          <textarea
-            ref={textareaRef}
-            value={prompt}
-            onChange={(e) => setPrompt(e.target.value)}
-            onKeyDown={handleKeyDown}
-            rows={1}
-            placeholder="描述你想生成的图片..."
-            className="w-full px-4 py-3 rounded-2xl border border-gray-200/60 dark:border-white/[0.08] bg-white/50 dark:bg-white/[0.03] text-sm focus:outline-none leading-relaxed resize-none shadow-sm transition-[border-color,box-shadow] duration-200"
-          />
+          <div className="relative">
+            {showAtImageMenu && (
+              <div style={{ left: `${menuLeft}px` }} className="absolute bottom-full z-50 mb-2 w-64 overflow-hidden rounded-2xl border border-gray-200/70 bg-white/95 p-1.5 shadow-xl ring-1 ring-black/5 backdrop-blur-xl dark:border-white/[0.08] dark:bg-gray-900/95 dark:ring-white/10">
+                <div className="px-2 pb-1 pt-0.5 text-[11px] text-gray-400 dark:text-gray-500">选择当前参考图</div>
+                <div className="max-h-56 overflow-y-auto custom-scrollbar">
+                  {atImageOptions.map(({ img, index }, optionIndex) => (
+                    <button
+                      key={img.id}
+                      type="button"
+                      onMouseDown={(e) => {
+                        e.preventDefault()
+                        selectAtImageOption(index)
+                      }}
+                      onMouseEnter={() => setAtImageMenuIndex(optionIndex)}
+                      className={`flex w-full items-center gap-2 rounded-xl px-2 py-1.5 text-left text-xs transition-colors ${
+                        optionIndex === atImageMenuIndex
+                          ? 'bg-blue-50 text-blue-600 dark:bg-blue-500/10 dark:text-blue-300'
+                          : 'text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-white/[0.06]'
+                      }`}
+                    >
+                      <span className="h-9 w-9 shrink-0 overflow-hidden rounded-lg border border-gray-200/70 dark:border-white/[0.08]">
+                        <img src={img.dataUrl} className="h-full w-full object-cover" alt="" />
+                      </span>
+                      <span className="min-w-0 flex-1 truncate font-medium">{getImageMentionLabel(index)}</span>
+                    </button>
+                  ))}
+                </div>
+              </div>
+            )}
+            <div
+              ref={textareaRef}
+              contentEditable
+              suppressContentEditableWarning
+              onInput={(e) => {
+                isUserInputRef.current = true
+                const el = e.currentTarget
+                setCursorPos(getContentEditableCursor(el))
+                const text = (el.textContent ?? '').replace(/\n/g, '')
+                setPrompt(text)
+                setAtImageMenuIndex(0)
+                setAtImageMenuDismissed(false)
+              }}
+              onSelect={() => {
+                if (textareaRef.current) {
+                  setCursorPos(getContentEditableCursor(textareaRef.current))
+                }
+                setAtImageMenuIndex(0)
+                setAtImageMenuDismissed(false)
+              }}
+              onKeyDown={handleKeyDown}
+              onClick={(e) => {
+                const el = textareaRef.current
+                if (!el) return
+                el.querySelectorAll('.mention-tag.selected').forEach((t) => t.classList.remove('selected'))
+                const target = e.target as HTMLElement
+                if (target.classList.contains('mention-tag')) {
+                  target.classList.add('selected')
+                  const sel = window.getSelection()
+                  if (sel) {
+                    const range = document.createRange()
+                    range.selectNode(target)
+                    sel.removeAllRanges()
+                    sel.addRange(range)
+                  }
+                }
+              }}
+              data-placeholder="描述你想生成的图片，可输入 @ 指定当前参考图..."
+              className="min-h-[42px] w-full whitespace-pre-wrap break-words rounded-2xl border border-gray-200/60 bg-white/50 px-4 py-3 text-sm leading-relaxed shadow-sm outline-none transition-[border-color,box-shadow] duration-200 focus:ring-1 focus:ring-blue-300/40 empty:before:pointer-events-none empty:before:text-gray-400 empty:before:content-[attr(data-placeholder)] dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-100 dark:focus:ring-blue-500/30 dark:empty:before:text-gray-500"
+            />
+          </div>
 
           {/* 参数 + 按钮 */}
           <div className="mt-3">

--- a/src/index.css
+++ b/src/index.css
@@ -223,3 +223,43 @@ input[type="number"] {
     font-size: 16px;
   }
 }
+
+/* contentEditable 中的 @图N 胶囊 tag */
+.mention-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 1px 8px;
+  margin: 0 4px;
+  border-radius: 9999px;
+  background: #dbeafe;
+  color: #2563eb;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  line-height: 1.5;
+  vertical-align: baseline;
+  user-select: all;
+  cursor: default;
+}
+
+.mention-tag::selection,
+.mention-tag *::selection {
+  background: transparent;
+  color: inherit;
+}
+
+.mention-tag:focus,
+.mention-tag.selected {
+  outline: 1.5px solid #93b4e8;
+  outline-offset: 0px;
+}
+
+@media (prefers-color-scheme: dark) {
+  .mention-tag {
+    background: rgba(59, 130, 246, 0.2);
+    color: #93c5fd;
+  }
+  .mention-tag:focus,
+  .mention-tag.selected {
+    outline-color: #7aa2d4;
+  }
+}

--- a/src/lib/domRect.ts
+++ b/src/lib/domRect.ts
@@ -1,0 +1,8 @@
+export function getSafeBoundingClientRect(element: Element | null | undefined): DOMRect | null {
+  if (!element || !element.isConnected || typeof element.getBoundingClientRect !== 'function') return null
+  try {
+    return element.getBoundingClientRect()
+  } catch {
+    return null
+  }
+}

--- a/src/lib/promptImageMentions.test.ts
+++ b/src/lib/promptImageMentions.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+import type { InputImage } from '../types'
+import { getAtImageQuery, getPromptMentionParts, insertImageMention, replaceImageMentionsForApi } from './promptImageMentions'
+
+const images: InputImage[] = [
+  { id: 'image-a', dataUrl: 'data:image/png;base64,a' },
+  { id: 'image-b', dataUrl: 'data:image/png;base64,b' },
+]
+
+describe('prompt image mentions', () => {
+  it('detects @ query after the cursor', () => {
+    expect(getAtImageQuery('参考 @图', 5, images)).toEqual({ start: 3, query: '图' })
+  })
+
+  it('ignores @ query when there are no current reference images', () => {
+    expect(getAtImageQuery('参考 @图', 5, [])).toBeNull()
+  })
+
+  it('ignores a completed image mention after selection', () => {
+    expect(getAtImageQuery('参考 @图2', 6, images)).toBeNull()
+  })
+
+  it('detects @ query in the middle of text without requiring whitespace prefix', () => {
+    expect(getAtImageQuery('参考@', 3, images)).toEqual({ start: 2, query: '' })
+  })
+
+  it('replaces middle-text @ query with selected current reference image mention', () => {
+    expect(insertImageMention('参考@生成', 2, 3, 1)).toEqual({
+      prompt: '参考 @图2 生成',
+      cursor: 7,
+    })
+  })
+
+
+
+  it('splits valid image mentions for tag rendering', () => {
+    expect(getPromptMentionParts('用@图2的方式生成@图9', images)).toEqual([
+      { type: 'text', text: '用' },
+      { type: 'mention', text: '@图2', imageIndex: 1 },
+      { type: 'text', text: '的方式生成@图9' },
+    ])
+  })
+
+  describe('replaceImageMentionsForApi', () => {
+    it('replaces single mention', () => {
+      expect(replaceImageMentionsForApi('把 @图1 变蓝')).toBe('把 [image 1] 变蓝')
+    })
+
+    it('replaces multiple mentions', () => {
+      expect(replaceImageMentionsForApi('把 @图2 的背景换到 @图1 上')).toBe('把 [image 2] 的背景换到 [image 1] 上')
+    })
+
+    it('returns prompt unchanged when no mentions', () => {
+      expect(replaceImageMentionsForApi('生成一只猫')).toBe('生成一只猫')
+    })
+  })
+})

--- a/src/lib/promptImageMentions.ts
+++ b/src/lib/promptImageMentions.ts
@@ -1,0 +1,80 @@
+import type { InputImage } from '../types'
+
+export interface AtImageQuery {
+  start: number
+  query: string
+}
+
+export function getImageMentionLabel(index: number) {
+  return `@图${index + 1}`
+}
+
+export function getAtImageQuery(prompt: string, cursor: number, inputImages: InputImage[]): AtImageQuery | null {
+  if (inputImages.length === 0) return null
+
+  const beforeCursor = prompt.slice(0, cursor)
+  const atIndex = beforeCursor.lastIndexOf('@')
+  if (atIndex < 0) return null
+
+  const query = beforeCursor.slice(atIndex + 1)
+  if (/\s/.test(query)) return null
+  const completedMention = query.match(/^图(\d+)$/)
+  if (completedMention) {
+    const index = Number(completedMention[1]) - 1
+    if (inputImages[index]) return null
+  }
+
+  return { start: atIndex, query }
+}
+
+export function imageMentionMatches(query: string, index: number) {
+  const normalized = query.trim().toLowerCase()
+  if (!normalized) return true
+
+  const oneBasedIndex = String(index + 1)
+  const label = `图${oneBasedIndex}`
+  return oneBasedIndex.includes(normalized) || label.toLowerCase().includes(normalized)
+}
+
+export function insertImageMention(prompt: string, start: number, cursor: number, imageIndex: number) {
+  const mention = getImageMentionLabel(imageIndex)
+  const prefix = start > 0 && prompt[start - 1] !== ' ' ? ' ' : ''
+  const suffix = prompt.slice(cursor)
+  const separator = suffix.startsWith(' ') || suffix.length === 0 ? '' : ' '
+  const nextPrompt = `${prompt.slice(0, start)}${prefix}${mention}${separator}${suffix}`
+  return {
+    prompt: nextPrompt,
+    cursor: start + prefix.length + mention.length + separator.length,
+  }
+}
+
+export type PromptMentionPart =
+  | { type: 'text'; text: string }
+  | { type: 'mention'; text: string; imageIndex: number }
+
+export function getPromptMentionParts(prompt: string, inputImages: InputImage[]): PromptMentionPart[] {
+  const parts: PromptMentionPart[] = []
+  let lastIndex = 0
+
+  for (const match of prompt.matchAll(/@图(\d+)/g)) {
+    const text = match[0]
+    const index = Number(match[1]) - 1
+    if (!inputImages[index] || match.index == null) continue
+
+    if (match.index > lastIndex) {
+      parts.push({ type: 'text', text: prompt.slice(lastIndex, match.index) })
+    }
+    parts.push({ type: 'mention', text, imageIndex: index })
+    lastIndex = match.index + text.length
+  }
+
+  if (lastIndex < prompt.length) {
+    parts.push({ type: 'text', text: prompt.slice(lastIndex) })
+  }
+
+  return parts.length > 0 ? parts : [{ type: 'text', text: prompt }]
+}
+
+export function replaceImageMentionsForApi(prompt: string): string {
+  return prompt.replace(/@图(\d+)/g, (_, n) => `[image ${n}]`)
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -12,6 +12,7 @@ import type {
 import { DEFAULT_PARAMS } from './types'
 import { DEFAULT_SETTINGS, getActiveApiProfile, getCustomProviderDefinition, mergeImportedSettings, normalizeSettings, validateApiProfile } from './lib/apiProfiles'
 import { dismissAllTooltips } from './lib/tooltipDismiss'
+import { replaceImageMentionsForApi } from './lib/promptImageMentions'
 import {
   CURRENT_THUMBNAIL_VERSION,
   getAllTasks,
@@ -1148,7 +1149,7 @@ async function executeTask(taskId: string) {
 
     const result = await callImageApi({
       settings: requestSettings,
-      prompt: task.prompt,
+      prompt: replaceImageMentionsForApi(task.prompt),
       params: task.params,
       inputImageDataUrls: inputDataUrls,
       maskDataUrl,


### PR DESCRIPTION
## 概述

PS: 一个小改动，通过 UI 和交互设计让图片引用看起来像全能参考，更贴合提示词输入的直觉。由于openai的API不支持在提示词中引用图片，因此 @mention 功能实际上是在提交时自动转为顺序标记来发挥作用。如图：
<img width="858" height="330" alt="ccec7272ae757860734559b72d351632" src="https://github.com/user-attachments/assets/e6ef2228-2396-40b0-a07f-9d3c5d3b76ff" />

将 prompt 输入框从 `<textarea>` 替换为 `contentEditable`，实现图片 @mention 功能。用户输入 `@` 后弹出已上传图片的选择菜单（跟随光标位置），选中后以胶囊样式内联显示。提交时 `@图N` 自动替换为 `[image N]`，让模型通过图片顺序理解引用关系。

## 主要改动

### 输入框重构
- `<textarea>` → `contentEditable <div>`，支持内联渲染 mention 胶囊

### @mention 交互
- 输入 `@` 触发图片选择下拉菜单，跟随光标位置弹出
- 支持键盘导航（↑↓ 选择、Enter 确认、Esc 关闭）
- 胶囊点击整体选中，按 Backspace 可删除

### API 提交处理
- 提交时将 `@图N` 替换为 `[image N]`，配合 API 按顺序接收图片的机制，让模型理解图片引用

### 工具库 (`src/lib/promptImageMentions.ts`)
- `getAtImageQuery` — 检测光标处的 @ 查询
- `imageMentionMatches` — 模糊匹配过滤
- `insertImageMention` — 插入 mention 并更新光标
- `getPromptMentionParts` — 解析 prompt 为文本/mention 片段用于渲染
- `replaceImageMentionsForApi` — 提交前替换为 `[image N]` 格式

## 测试

- `npm run build` 通过
- 单元测试覆盖 mention 解析和替换逻辑
- Edge 浏览器手动验证：输入 @、选择图片、胶囊显示/选中/删除、候选框跟随光标、提交替换均正常
