### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -20,6 +20,9 @@ import {
   normalizeCustomProviderDefinition,
   normalizeSettings,
   switchApiProfileProvider,
+  ASTRAFLOW_PROVIDER_DEFINITION,
+  ASTRAFLOW_BASE_URL_GLOBAL,
+  ASTRAFLOW_BASE_URL_CN,
 } from '../lib/apiProfiles'
 import { copyTextToClipboard, getClipboardFailureMessage } from '../lib/clipboard'
 import type { ApiProfile, AppSettings, CustomProviderDefinition } from '../types'
@@ -36,6 +39,9 @@ function newId(prefix: string) {
 }
 
 const ADD_CUSTOM_PROVIDER_VALUE = '__add_custom_provider__'
+const ADD_ASTRAFLOW_GLOBAL_VALUE = '__add_astraflow_global__'
+const ADD_ASTRAFLOW_CN_VALUE = '__add_astraflow_cn__'
+
 const COPY_IMPORT_URL_OPTIONS_STORAGE_KEY = 'gpt-image-playground.copy-import-url-options'
 
 const DEFAULT_COPY_IMPORT_URL_OPTIONS = {
@@ -355,6 +361,8 @@ export default function SettingsModal() {
 
   const providerOptions = [
     { label: '创建自定义服务商', value: ADD_CUSTOM_PROVIDER_VALUE, variant: 'action' as const },
+    { label: '添加 Astraflow（全球节点）', value: ADD_ASTRAFLOW_GLOBAL_VALUE, variant: 'action' as const },
+    { label: '添加 Astraflow（中国节点）', value: ADD_ASTRAFLOW_CN_VALUE, variant: 'action' as const },
     ...unorderedProviderOptions.sort((a, b) => {
       const aIndex = providerOrder.indexOf(String(a.value))
       const bIndex = providerOrder.indexOf(String(b.value))
@@ -854,6 +862,14 @@ export default function SettingsModal() {
   }
 
   const handleProviderTypeChange = (value: string | number) => {
+    if (value === ADD_ASTRAFLOW_GLOBAL_VALUE) {
+      addAstraflowProvider(ASTRAFLOW_BASE_URL_GLOBAL)
+      return
+    }
+    if (value === ADD_ASTRAFLOW_CN_VALUE) {
+      addAstraflowProvider(ASTRAFLOW_BASE_URL_CN)
+      return
+    }
     if (value === ADD_CUSTOM_PROVIDER_VALUE) {
       setEditingCustomProviderId(null)
       setCustomProviderForm(createDefaultCustomProviderForm())

--- a/src/lib/apiProfiles.ts
+++ b/src/lib/apiProfiles.ts
@@ -255,6 +255,57 @@ export function normalizeCustomProviderDefinitions(input: unknown): CustomProvid
     .filter((item): item is CustomProviderDefinition => Boolean(item))
 }
 
+export const ASTRAFLOW_PROVIDER_DEFINITION: CustomProviderDefinition = {
+  id: 'custom-astraflow',
+  name: 'Astraflow (UCloud)',
+  template: 'http-image',
+  submit: {
+    path: 'images/generations',
+    method: 'POST',
+    contentType: 'json',
+    body: {
+      model: '$profile.model',
+      prompt: '$prompt',
+      size: '$params.size',
+      quality: '$params.quality',
+      output_format: '$params.output_format',
+      moderation: '$params.moderation',
+      output_compression: '$params.output_compression',
+      n: '$params.n',
+    },
+    result: {
+      imageUrlPaths: ['data.*.url'],
+      b64JsonPaths: ['data.*.b64_json'],
+    },
+  },
+  editSubmit: {
+    path: 'images/edits',
+    method: 'POST',
+    contentType: 'multipart',
+    body: {
+      model: '$profile.model',
+      prompt: '$prompt',
+      size: '$params.size',
+      quality: '$params.quality',
+      output_format: '$params.output_format',
+      moderation: '$params.moderation',
+      output_compression: '$params.output_compression',
+      n: '$params.n',
+    },
+    files: [
+      { field: 'image[]', source: 'inputImages', array: true },
+      { field: 'mask', source: 'mask' },
+    ],
+    result: {
+      imageUrlPaths: ['data.*.url'],
+      b64JsonPaths: ['data.*.b64_json'],
+    },
+  },
+}
+
+export const ASTRAFLOW_BASE_URL_GLOBAL = 'https://api-us-ca.umodelverse.ai/v1'
+export const ASTRAFLOW_BASE_URL_CN = 'https://api.modelverse.cn/v1'
+
 export function createDefaultOpenAIProfile(overrides: Partial<ApiProfile> = {}): ApiProfile {
   return {
     id: DEFAULT_OPENAI_PROFILE_ID,


### PR DESCRIPTION
## Summary

Adds [Astraflow by UCloud](https://astraflow.ucloud-global.com) as a supported provider in the settings UI.

Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models. Because it uses the standard OpenAI API format, integration is done by registering it as a custom provider with the appropriate `base_url`.

## Changes

### `src/lib/apiProfiles.ts`
- Exports `ASTRAFLOW_PROVIDER_DEFINITION` — a `CustomProviderDefinition` for Astraflow using the standard OpenAI-compatible images/generations and images/edits endpoints
- Exports `ASTRAFLOW_BASE_URL_GLOBAL` (`https://api-us-ca.umodelverse.ai/v1`) and `ASTRAFLOW_BASE_URL_CN` (`https://api.modelverse.cn/v1`) constants

### `src/components/SettingsModal.tsx`
- Imports the new Astraflow constants
- Adds two quick-add actions to the provider dropdown:
  - **添加 Astraflow（全球节点）** — pre-fills the global endpoint
  - **添加 Astraflow（中国节点）** — pre-fills the China endpoint
- Adds `addAstraflowProvider()` helper that creates both a custom provider definition and a matching API profile in one click

## How to use
1. Open Settings → API tab
2. Click the provider dropdown
3. Select "添加 Astraflow（全球节点）" or "添加 Astraflow（中国节点）"
4. Fill in your API key (get one at https://astraflow.ucloud-global.com or https://astraflow.ucloud.cn)
5. Select a model and start generating

No new packages, no new directories — only two existing source files modified.