### PR TITLE
fix: 升级 dompurify 至 3.4.7 修复高危 XSS 漏洞

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3514,9 +3514,9 @@
       "license": "MIT"
     },
     "node_modules/dompurify": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.4.tgz",
-      "integrity": "sha512-r8K7KGKEcztXfA/nfabSYB2hg9tDphORJTdf8xprN/luSLGmNhOBN8dm1/SYjqLLet6YUFEXOcrdTuwryp/Bew==",
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.7.tgz",
+      "integrity": "sha512-2jBxDJY4RR06tQNy4w5FlFH7kfxsQZlufd0sbv+chfHCxeJwrFw2baUDsSwvBISD4K4RDbd0PTfy3uNXsR6siA==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "zustand": "^5.0.5"
   },
   "overrides": {
-    "mdast-util-gfm-autolink-literal": "2.0.0"
+    "mdast-util-gfm-autolink-literal": "2.0.0",
+    "dompurify": "^3.4.7"
   },
   "devDependencies": {
     "@types/react": "^19.1.2",


### PR DESCRIPTION
`dompurify@3.4.4` 存在高危 XSS 漏洞（[GHSA-87xg-pxx2-7hvx](https://github.com/advisories/GHSA-87xg-pxx2-7hvx)，CVSS 8.2），经 `streamdown → mermaid` 间接引入。该版本在处理 `<selectedcontent>` 元素时存在 sanitization 绕过，渲染不可信 Markdown（如中转 / 第三方 API 返回的含 mermaid 内容）时可被利用执行脚本。

通过 `overrides` 升级至 3.4.7，满足 mermaid 的 `^3.3.1` 约束，无破坏性变更：

```json
"overrides": {
  "mdast-util-gfm-autolink-literal": "2.0.0",
  "dompurify": "^3.4.7"
}
```

已验证 `build` / `test`（177 passed）/ `npm audit` 均通过。