### PR TITLE
feat: add clear failed task action / 添加清理失败记录入口

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,6 +1,6 @@
-import { useStore } from '../store'
+import { clearFailedTasks, useStore } from '../store'
 import Select from './Select'
-import { ChevronLeftIcon, FavoriteIcon, CollectionManageIcon } from './icons'
+import { ChevronLeftIcon, CollectionManageIcon, FavoriteIcon, TrashIcon } from './icons'
 
 export default function SearchBar() {
   const searchQuery = useStore((s) => s.searchQuery)
@@ -12,7 +12,11 @@ export default function SearchBar() {
   const activeFavoriteCollectionId = useStore((s) => s.activeFavoriteCollectionId)
   const setActiveFavoriteCollectionId = useStore((s) => s.setActiveFavoriteCollectionId)
   const openManageCollectionsModal = useStore((s) => s.openManageCollectionsModal)
+  const tasks = useStore((s) => s.tasks)
+  const setConfirmDialog = useStore((s) => s.setConfirmDialog)
   const inCollectionOverview = filterFavorite && !activeFavoriteCollectionId
+  const failedTaskIds = tasks.filter((task) => task.status === 'error').map((task) => task.id)
+  const failedCount = failedTaskIds.length
 
   const handleFavoriteClick = () => {
     if (activeFavoriteCollectionId) {
@@ -20,6 +24,19 @@ export default function SearchBar() {
       return
     }
     setFilterFavorite(!filterFavorite)
+  }
+
+  const handleClearFailed = () => {
+    if (failedCount === 0) return
+
+    setConfirmDialog({
+      title: '清除失败记录',
+      message: `是否清除所有生成失败的记录？\n将删除 ${failedCount} 条失败记录，关联的孤立图片资源也会被清理。`,
+      confirmText: '删除',
+      cancelText: '取消',
+      tone: 'danger',
+      action: () => clearFailedTasks(),
+    })
   }
 
   return (
@@ -46,22 +63,34 @@ export default function SearchBar() {
           </button>
         )}
         {!inCollectionOverview && (
-          <div className="relative w-28">
-            <Select
-              value={filterStatus}
-              onChange={(val) => setFilterStatus(val as any)}
-              options={[
-                { label: '全部状态', value: 'all' },
-                { label: '已完成', value: 'done' },
-                { label: '生成中', value: 'running' },
-                { label: '失败', value: 'error' },
-              ]}
-              className="px-3 py-2.5 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-white/[0.06] text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition"
-            />
-          </div>
+          <>
+            <div className="relative w-28">
+              <Select
+                value={filterStatus}
+                onChange={(val) => setFilterStatus(val as any)}
+                options={[
+                  { label: '全部状态', value: 'all' },
+                  { label: '已完成', value: 'done' },
+                  { label: '生成中', value: 'running' },
+                  { label: '失败', value: 'error' },
+                ]}
+                className="px-3 py-2.5 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-gray-900 hover:bg-gray-50 dark:hover:bg-white/[0.06] text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition"
+              />
+            </div>
+            <button
+              type="button"
+              onClick={handleClearFailed}
+              disabled={failedCount === 0}
+              title={failedCount > 0 ? `清除 ${failedCount} 条失败记录` : '没有失败记录'}
+              aria-label={failedCount > 0 ? `清除 ${failedCount} 条失败记录` : '没有失败记录'}
+              className="flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-xl border border-gray-200 bg-white text-gray-400 transition-all hover:bg-gray-50 hover:text-gray-600 focus:outline-none focus:ring-2 focus:ring-blue-500/30 disabled:cursor-not-allowed disabled:opacity-55 disabled:hover:bg-white disabled:hover:text-gray-400 dark:border-white/[0.08] dark:bg-gray-900 dark:text-gray-500 dark:hover:bg-white/[0.06] dark:hover:text-gray-300 dark:disabled:hover:bg-gray-900 dark:disabled:hover:text-gray-500"
+            >
+              <TrashIcon className="h-[18px] w-[18px]" />
+            </button>
+          </>
         )}
       </div>
-      <div className="relative flex-1 z-10">
+      <div className="relative z-10 flex-1">
         <svg
           className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500"
           fill="none"

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -97,7 +97,7 @@ vi.mock('./lib/agentApi', () => ({
 }))
 import { clearAgentConversations, clearImages, clearTasks, getAllAgentConversations, getAllTasks, putAgentConversation, putImage, putTask as putDbTask } from './lib/db'
 import { callAgentResponsesApi, callBatchImageSingle } from './lib/agentApi'
-import { cleanStaleAgentInputDrafts, deleteAgentRoundFromConversation, deleteFavoriteCollection, editOutputs, getActiveAgentRounds, getErrorToastMessage, getPersistedState, getTaskApiProfile, importData, initStore, markInterruptedOpenAIRunningTasks, migratePersistedState, regenerateAgentAssistantMessage, remapAgentRoundMentionsForPathChange, removeTask, reuseConfig, submitAgentMessage, submitTask, useStore } from './store'
+import { cleanStaleAgentInputDrafts, clearFailedTasks, deleteAgentRoundFromConversation, deleteFavoriteCollection, editOutputs, getActiveAgentRounds, getErrorToastMessage, getPersistedState, getTaskApiProfile, importData, initStore, markInterruptedOpenAIRunningTasks, migratePersistedState, regenerateAgentAssistantMessage, remapAgentRoundMentionsForPathChange, removeTask, reuseConfig, submitAgentMessage, submitTask, useStore } from './store'
 
 const imageA = { id: 'image-a', dataUrl: 'data:image/png;base64,a' }
 const imageB = { id: 'image-b', dataUrl: 'data:image/png;base64,b' }
@@ -1431,6 +1431,25 @@ describe('agent context for removed outputs', () => {
     const serializedConversations = JSON.stringify(state.agentConversations)
     expect(serializedConversations).toContain('function_call_output')
     expect(serializedConversations).not.toContain('batch-deleted-base64')
+  })
+
+  it('clears only failed gallery tasks', async () => {
+    const failedA = task({ id: 'failed-a', status: 'error', error: '生成失败', outputImages: ['failed-image-a'] })
+    const failedB = task({ id: 'failed-b', status: 'error', error: '生成失败', outputImages: ['failed-image-b'] })
+    const done = task({ id: 'done-task', status: 'done', outputImages: ['done-image'] })
+    const running = task({ id: 'running-task', status: 'running', finishedAt: null, elapsed: null })
+    useStore.setState({
+      tasks: [failedA, done, failedB, running],
+      selectedTaskIds: ['failed-a', 'done-task', 'failed-b'],
+      showToast: vi.fn(),
+    })
+
+    await clearFailedTasks()
+
+    const state = useStore.getState()
+    expect(state.tasks.map((item) => item.id)).toEqual(['done-task', 'running-task'])
+    expect(state.selectedTaskIds).toEqual(['done-task'])
+    expect(state.showToast).toHaveBeenCalledWith('已删除 2 个任务', 'success')
   })
 })
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -4489,6 +4489,16 @@ export async function removeMultipleTasks(taskIds: string[]) {
   showToast(`已删除 ${taskIds.length} 个任务`, 'success')
 }
 
+/** 删除所有失败任务 */
+export async function clearFailedTasks() {
+  const failedTaskIds = useStore.getState().tasks
+    .filter((task) => task.status === 'error')
+    .map((task) => task.id)
+
+  if (!failedTaskIds.length) return
+  await removeMultipleTasks(failedTaskIds)
+}
+
 /** 删除单条任务 */
 export async function removeTask(task: TaskRecord) {
   const { tasks, setTasks, inputImages, galleryInputDraft, showToast } = useStore.getState()


### PR DESCRIPTION
## 摘要 / Summary

- 在画廊状态筛选旁新增紧凑垃圾桶按钮 / Add a compact trash action next to the gallery status filter
- 清理所有失败生成记录前弹出确认框 / Confirm before clearing all failed generation records
- 通过 `clearFailedTasks()` 复用现有批量删除流程 / Reuse the existing multi-task deletion flow via `clearFailedTasks()`
- 增加 store 测试，验证完成任务和运行任务会被保留 / Cover the action with a store test that preserves done and running tasks

Closes #94

## 验证 / Verification

- `npm test`
- `npm run build`