### PR TITLE
fix(agent): avoid duplicating assistant message when response.completed lacks item id

### DIFF
--- a/src/lib/agentApi.test.ts
+++ b/src/lib/agentApi.test.ts
@@ -306,4 +306,53 @@ describe('callAgentResponsesApi', () => {
     body = JSON.parse(String((fetchMock.mock.calls[1][1] as RequestInit).body))
     expect(body.instructions).not.toContain('## Math formatting')
   })
+
+  it("does not duplicate the assistant message item when response.completed lacks an item id", async () => {
+    // Real-world Responses API SSE stream: response.output_item.added/done emit the item
+    // with a stable id; response.completed re-states the same item inside response.output
+    // but WITHOUT the id. The publishOutputItems dedupe must not push that as a new item,
+    // otherwise the message gets rendered twice in the agent UI.
+    const itemId = "msg_abc123"
+    const streamBody = [
+      `data: {"type":"response.created","response":{"id":"resp_1","output":[]}}`,
+      ``,
+      `data: {"type":"response.output_item.added","item":{"id":"${itemId}","type":"message","status":"in_progress","content":[],"role":"assistant"}}`,
+      ``,
+      `data: {"type":"response.output_text.delta","delta":"hi","item_id":"${itemId}"}`,
+      ``,
+      `data: {"type":"response.output_text.delta","delta":"!","item_id":"${itemId}"}`,
+      ``,
+      `data: {"type":"response.output_item.done","item":{"id":"${itemId}","type":"message","status":"completed","content":[{"type":"output_text","text":"hi!"}],"role":"assistant"}}`,
+      ``,
+      `data: {"type":"response.completed","response":{"id":"resp_1","output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi!"}]}]}}`,
+      ``,
+      `data: [DONE]`,
+      ``,
+    ].join("\n")
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(streamBody, {
+      status: 200,
+      headers: { "Content-Type": "text/event-stream" },
+    }))
+    const outputItemSnapshots: number[] = []
+    const profile = createDefaultOpenAIProfile({
+      apiKey: "test-key",
+      apiMode: "responses",
+      streamImages: true,
+    })
+
+    const result = await callAgentResponsesApi({
+      settings: DEFAULT_SETTINGS,
+      profile,
+      params: DEFAULT_PARAMS,
+      input: [{ role: "user", content: [{ type: "input_text", text: "hi" }] }],
+      onOutputItems: (items) => outputItemSnapshots.push(items.length),
+    })
+
+    // The response.completed re-emit (without id) must be matched against the existing
+    // streamed item, not appended.
+    const messageItems = (result.outputItems ?? []).filter((item) => item.type === "message")
+    expect(messageItems).toHaveLength(1)
+    expect(result.text).toBe("hi!")
+    expect(outputItemSnapshots[outputItemSnapshots.length - 1]).toBe(1)
+  })
 })

--- a/src/lib/agentApi.ts
+++ b/src/lib/agentApi.ts
@@ -511,9 +511,30 @@ async function parseAgentStreamResponse(
   const outputItems: ResponsesOutputItem[] = []
   let streamedText = ''
 
-  const publishOutputItems = (items: ResponsesOutputItem[]) => {
-    for (const item of items) {
-      const index = item.id ? outputItems.findIndex((existing) => existing.id === item.id) : -1
+  const publishOutputItems = (items: ResponsesOutputItem[], outputIndices?: Array<number | undefined>) => {
+    for (let i = 0; i < items.length; i += 1) {
+      const item = items[i]
+      const outputIndex = outputIndices?.[i]
+      let index = item.id ? outputItems.findIndex((existing) => existing.id === item.id) : -1
+      // The terminal `response.completed` event re-emits the streamed items inside its
+      // `response.output` array, but those copies omit the per-item `id` field. Without
+      // a secondary match, the dedupe above would treat each one as a new entry and the
+      // assistant message would render twice in the agent UI. When we know the
+      // output_index (or it is 0 and we currently track one item of the same type),
+      // match the existing slot instead of appending.
+      if (index < 0 && !item.id && typeof outputIndex === "number" && outputIndex >= 0 && outputIndex < outputItems.length) {
+        const candidate = outputItems[outputIndex]
+        if (candidate?.type === item.type) index = outputIndex
+      }
+      if (index < 0 && !item.id && item.type) {
+        // Fallback: match by type when only one tracked item shares it. This covers the
+        // common single-message turn shape without risking false matches across distinct
+        // tool calls.
+        const sameTypeIndices = outputItems
+          .map((existing, idx) => existing.type === item.type ? idx : -1)
+          .filter((idx) => idx >= 0)
+        if (sameTypeIndices.length === 1) index = sameTypeIndices[0]
+      }
       if (index >= 0) outputItems[index] = item
       else outputItems.push(item)
     }
@@ -585,7 +606,11 @@ async function parseAgentStreamResponse(
     if (!payload) return
 
     if (Array.isArray(payload.output)) {
-      publishOutputItems(payload.output)
+      // For the terminal `response.completed` snapshot the per-item `output_index` is
+      // implicit (== array index). Hand it to publishOutputItems so the dedupe can match
+      // streamed items that lost their id in the snapshot.
+      const indices = type === "response.completed" ? payload.output.map((_, idx) => idx) : undefined
+      publishOutputItems(payload.output, indices)
     }
 
     if (type === 'response.output_item.added') {


### PR DESCRIPTION
## 现象 / Symptom

Agent 模式开启流式后,纯文本回复会被渲染**两次** —— 同一个 article 内出现两个并列的 `<div class="markdown-renderer">`,第二个带 `mt-3`。

复现步骤:
1. Agent 模式 + 流式开启
2. 输入任意"不画图、纯聊天"的 prompt(例如 `不要画图，先聊聊，你说hi`)
3. 模型只返回一段文本(如 `hi! 👋`)
4. 页面渲染出两段 `hi! 👋`

非流式模式、画廊模式不受影响。

DOM 实证:
```html
<div data-selectable-text="true" ...>
  <div><div class="markdown-renderer">hi! 👋</div></div>
  <div class="mt-3"><div class="markdown-renderer">hi! 👋</div></div>
</div>
```

## 根因 / Root cause

来自 `parseAgentStreamResponse` 里的 `publishOutputItems`:

- SSE 流中 `response.output_item.added` / `.done` 都带稳定的 `item.id`(例如 `msg_abc123`)。
- 终结事件 `response.completed` 会在 `response.output` 里**再发一次同样的 message item**,但**那份 snapshot 不带 `id`**。
- `publishOutputItems` 只按 `id` dedupe;无 id 的那份就被当成新条目 push 进来。
- `getAgentAssistantBlocks` 遍历 `outputItems`,两条 message 各产生一个 text block,渲染翻倍。

抓到的 SSE 帧确认了这一点(节选自 `gpt-5.5` 实测):

```jsonc
// response.output_item.done — 带 id
{"type":"response.output_item.done","item":{"id":"msg_05...","type":"message","content":[{"type":"output_text","text":"hi! 👋"}],...}}

// response.completed — 同一个 message,但 output[0] 没有 id
{"type":"response.completed","response":{"output":[{"type":"message","role":"assistant","content":[{"type":"output_text","text":"hi! 👋"}]}]}}
```

## 修复 / Fix

仅改 `src/lib/agentApi.ts` 的 `publishOutputItems`。新增两层兜底匹配:

1. 入参可选 `outputIndices`,当 item 没 id 但知道在 `response.output` 里的位置时,按位匹配已有项。
2. 都不知道时回退到"在已追踪项里只有一个同 type 的 → 视为同一个"的最小启发,避免误匹配跨工具调用。

主循环对 `response.completed` 显式传位置索引(`payload.output.map((_, i) => i)`),让无 id 的快照与流式来的真实 item 在原位合并,而不是追加。

只动累加器层,渲染和 store 完全不变。

## 测试 / Tests

新增一个回归测试,喂一段贴近真实形态的 SSE(`output_item.added → delta×2 → output_item.done → completed-without-id`),断言最终 `result.outputItems` 只含一个 message,最后一次发布的 snapshot 也只有一个。

`vitest run` 全套通过(16 文件 / 210 用例)。

## 与既有 issue 的关系 / Relation to existing issues

#100 评论里已经有用户反映"开流式就重复消息,关掉就没事";那条 issue 后被 CDN/字体话题带跑、最终被关闭。这个 PR 是用另一组实证(SSE 原文 + DOM)定位到的根因,**适用于 #100 报告的 streaming 重复部分**(输入框/字体那段不在范围内)。

## Changelog 建议

- Fixed: Agent 模式开启流式时,纯文本回复在页面上出现两次的问题。