### PR TITLE
feat: add case gallery mode for prompt inspiration library

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import Header from './components/Header'
 import SearchBar from './components/SearchBar'
 import TaskGrid from './components/TaskGrid'
 import AgentWorkspace from './components/AgentWorkspace'
+import CaseGallery from './components/CaseGallery'
 import InputBar from './components/InputBar'
 import DetailModal from './components/DetailModal'
 import Lightbox from './components/Lightbox'
@@ -112,6 +113,8 @@ export default function App() {
       <Header />
       {appMode === 'agent' ? (
         <AgentWorkspace />
+      ) : appMode === 'cases' ? (
+        <CaseGallery />
       ) : (
         <main data-home-main data-drag-select-surface className="pb-48">
           <div className="safe-area-x max-w-7xl mx-auto">

--- a/src/components/CaseCard.tsx
+++ b/src/components/CaseCard.tsx
@@ -1,0 +1,134 @@
+import { useState } from 'react'
+import type { CaseRecord } from '../types'
+import { getImageUrl } from '../data/caseData'
+
+interface Props {
+  caseItem: CaseRecord
+  onCopyPrompt: (text: string) => void
+  onOpenPreview: (item: CaseRecord) => void
+}
+
+export default function CaseCard({ caseItem, onCopyPrompt, onOpenPreview }: Props) {
+  const [imgLoaded, setImgLoaded] = useState(false)
+  const [imgError, setImgError] = useState(false)
+
+  const tags = [...new Set([...caseItem.styles, ...caseItem.scenes])].slice(0, 4)
+
+  return (
+    <article
+      className="rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-gray-900 overflow-hidden flex flex-col hover:-translate-y-1 hover:border-cyan-400/50 hover:shadow-lg transition-all duration-200"
+      style={{ contentVisibility: 'auto', containIntrinsicSize: 'auto 340px' }}
+    >
+      {/* Image */}
+      <button
+        type="button"
+        onClick={() => onOpenPreview(caseItem)}
+        className="relative block w-full overflow-hidden bg-gray-100 dark:bg-white/[0.05] cursor-pointer border-0 p-0 text-left group"
+      >
+        {!imgError ? (
+          <img
+            src={getImageUrl(caseItem.image)}
+            alt={caseItem.imageAlt}
+            loading="lazy"
+            onLoad={() => setImgLoaded(true)}
+            onError={() => setImgError(true)}
+            className={`w-full h-auto block transition-all duration-300 ${imgLoaded ? 'opacity-100' : 'opacity-0'} group-hover:scale-[1.025]`}
+          />
+        ) : (
+          <div className="w-full aspect-[4/3] flex items-center justify-center text-gray-400 text-sm bg-gray-100 dark:bg-white/[0.05]">
+            图片加载失败
+          </div>
+        )}
+        {!imgLoaded && !imgError && (
+          <div className="absolute inset-0 aspect-[4/3] animate-pulse bg-gray-200 dark:bg-white/[0.06]" />
+        )}
+        <span className="absolute left-2.5 top-2.5 px-2 py-1 rounded-md text-[11px] font-black bg-black/70 text-white backdrop-blur-sm">
+          案例 {caseItem.id}
+        </span>
+        <span className="absolute right-2.5 bottom-2.5 inline-flex items-center gap-1.5 px-2 py-1.5 rounded-md border border-cyan-400/40 bg-black/70 text-cyan-50 text-xs font-black opacity-0 translate-y-1.5 group-hover:opacity-100 group-hover:translate-y-0 transition-all duration-200 pointer-events-none">
+          <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+          </svg>
+          查看详情
+        </span>
+      </button>
+
+      <div className="flex flex-col flex-1 p-3">
+        <div className="flex flex-wrap gap-x-2 gap-y-0.5 text-[11px] font-extrabold uppercase tracking-wide text-cyan-600 dark:text-cyan-400 mb-1.5">
+          <span>{caseItem.category}</span>
+          {caseItem.sourceUrl ? (
+            <a
+              href={caseItem.sourceUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-emerald-600 dark:text-emerald-400 hover:underline"
+              onClick={(e) => e.stopPropagation()}
+            >
+              {caseItem.sourceLabel}
+            </a>
+          ) : (
+            <span className="text-emerald-600 dark:text-emerald-400">{caseItem.sourceLabel}</span>
+          )}
+        </div>
+
+        <h3 className="text-base font-bold leading-tight text-gray-800 dark:text-gray-100 mb-1">
+          {caseItem.title}
+        </h3>
+
+        <p className="text-[11px] text-gray-500 dark:text-gray-400 leading-relaxed line-clamp-2 mb-2">
+          {caseItem.promptPreview || caseItem.prompt.slice(0, 200)}
+        </p>
+
+        {tags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-2">
+            {tags.map((tag) => (
+              <span
+                key={`${caseItem.id}-${tag}`}
+                className="px-1.5 py-0.5 rounded-full text-[10px] bg-gray-100 dark:bg-white/[0.06] text-gray-500 dark:text-gray-400"
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        <div className="grid grid-cols-3 gap-1.5 pt-2 border-t border-gray-100 dark:border-white/[0.06]">
+          <button
+            type="button"
+            onClick={() => onCopyPrompt(caseItem.prompt)}
+            className="inline-flex items-center justify-center gap-1 py-1 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-gray-50 dark:bg-white/[0.04] text-gray-600 dark:text-gray-400 text-[11px] font-bold hover:bg-gray-100 dark:hover:bg-white/[0.08] transition-colors"
+          >
+            <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+            </svg>
+            复制
+          </button>
+          <button
+            type="button"
+            onClick={() => onOpenPreview(caseItem)}
+            className="inline-flex items-center justify-center gap-1 py-1 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-gray-50 dark:bg-white/[0.04] text-gray-600 dark:text-gray-400 text-[11px] font-bold hover:bg-gray-100 dark:hover:bg-white/[0.08] transition-colors"
+          >
+            <svg className="w-3 h-3 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
+            </svg>
+            详情
+          </button>
+          <a
+            href={caseItem.githubUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center justify-center py-1 rounded-lg border border-gray-200 dark:border-white/[0.08] bg-gray-50 dark:bg-white/[0.04] text-gray-400 dark:text-gray-500 hover:bg-gray-100 dark:hover:bg-white/[0.08] transition-colors"
+            onClick={(e) => e.stopPropagation()}
+            title="GitHub"
+          >
+            <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+            </svg>
+          </a>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/components/CaseFilter.tsx
+++ b/src/components/CaseFilter.tsx
@@ -1,0 +1,69 @@
+import type { CaseFilterDef, CaseCategoryDef } from '../types'
+
+interface Props {
+  categories: CaseCategoryDef[]
+  styles: CaseFilterDef[]
+  scenes: CaseFilterDef[]
+  activeCategory: string | null
+  activeStyle: string | null
+  activeScene: string | null
+  onCategoryChange: (c: string | null) => void
+  onStyleChange: (s: string | null) => void
+  onSceneChange: (s: string | null) => void
+}
+
+function FilterSection({
+  label,
+  items,
+  activeValue,
+  onChange,
+}: {
+  label: string
+  items: { id: string; value: string; title: { zh: string } }[]
+  activeValue: string | null
+  onChange: (v: string | null) => void
+}) {
+  return (
+    <div className="mb-3">
+      <span className="text-xs font-medium text-gray-400 dark:text-gray-500 mr-2">{label}</span>
+      <div className="inline-flex flex-wrap gap-1.5">
+        {items.map((item) => {
+          const isActive = activeValue === item.value
+          return (
+            <button
+              key={item.id}
+              onClick={() => onChange(isActive ? null : item.value)}
+              className={`px-2.5 py-1 rounded-lg text-xs transition-all ${
+                isActive
+                  ? 'bg-blue-500 text-white shadow-sm'
+                  : 'bg-gray-100 dark:bg-white/[0.06] text-gray-600 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-white/[0.1]'
+              }`}
+            >
+              {item.title.zh}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export default function CaseFilter({
+  categories,
+  styles,
+  scenes,
+  activeCategory,
+  activeStyle,
+  activeScene,
+  onCategoryChange,
+  onStyleChange,
+  onSceneChange,
+}: Props) {
+  return (
+    <div data-no-drag-select className="mb-4 p-3 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-gray-900">
+      <FilterSection label="分类" items={categories} activeValue={activeCategory} onChange={onCategoryChange} />
+      <FilterSection label="风格" items={styles} activeValue={activeStyle} onChange={onStyleChange} />
+      <FilterSection label="场景" items={scenes} activeValue={activeScene} onChange={onSceneChange} />
+    </div>
+  )
+}

--- a/src/components/CaseGallery.tsx
+++ b/src/components/CaseGallery.tsx
@@ -1,0 +1,264 @@
+import { useEffect, useState, useMemo, useRef, useCallback } from 'react'
+import { useStore } from '../store'
+import { fetchCases, fetchStyleLibrary } from '../data/caseData'
+import type { CaseRecord, CaseStyleLibrary } from '../types'
+import CaseFilter from './CaseFilter'
+import CaseCard from './CaseCard'
+import CasePreview from './CasePreview'
+
+const BATCH_SIZE = 24
+
+type LoadState = 'loading' | 'loaded' | 'error'
+
+export default function CaseGallery() {
+  const caseSearchQuery = useStore((s) => s.caseSearchQuery)
+  const setCaseSearchQuery = useStore((s) => s.setCaseSearchQuery)
+  const caseFilterCategory = useStore((s) => s.caseFilterCategory)
+  const setCaseFilterCategory = useStore((s) => s.setCaseFilterCategory)
+  const caseFilterStyle = useStore((s) => s.caseFilterStyle)
+  const setCaseFilterStyle = useStore((s) => s.setCaseFilterStyle)
+  const caseFilterScene = useStore((s) => s.caseFilterScene)
+  const setCaseFilterScene = useStore((s) => s.setCaseFilterScene)
+  const showToast = useStore((s) => s.showToast)
+
+  const [cases, setCases] = useState<CaseRecord[]>([])
+  const [styleLib, setStyleLib] = useState<CaseStyleLibrary | null>(null)
+  const [loadState, setLoadState] = useState<LoadState>('loading')
+  const [errorMessage, setErrorMessage] = useState('')
+  const [visibleCount, setVisibleCount] = useState(BATCH_SIZE)
+  const [previewCase, setPreviewCase] = useState<CaseRecord | null>(null)
+  const sentinelRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    async function load() {
+      setLoadState('loading')
+      try {
+        const [casesData, styleData] = await Promise.all([fetchCases(), fetchStyleLibrary()])
+        if (cancelled) return
+        setCases(casesData)
+        setStyleLib(styleData)
+        setLoadState('loaded')
+      } catch (err) {
+        if (cancelled) return
+        setErrorMessage(err instanceof Error ? err.message : '加载失败')
+        setLoadState('error')
+      }
+    }
+    load()
+    return () => { cancelled = true }
+  }, [])
+
+  const filteredCases = useMemo(() => {
+    let result = cases
+    const q = caseSearchQuery.trim().toLowerCase()
+
+    if (caseFilterCategory) {
+      result = result.filter((c) => c.category === caseFilterCategory)
+    }
+    if (caseFilterStyle) {
+      result = result.filter((c) => c.styles.includes(caseFilterStyle))
+    }
+    if (caseFilterScene) {
+      result = result.filter((c) => c.scenes.includes(caseFilterScene))
+    }
+    if (q) {
+      result = result.filter(
+        (c) =>
+          c.title.toLowerCase().includes(q) ||
+          c.sourceLabel.toLowerCase().includes(q) ||
+          c.prompt.toLowerCase().includes(q),
+      )
+    }
+    return result
+  }, [cases, caseSearchQuery, caseFilterCategory, caseFilterStyle, caseFilterScene])
+
+  useEffect(() => {
+    setVisibleCount(BATCH_SIZE)
+  }, [caseSearchQuery, caseFilterCategory, caseFilterStyle, caseFilterScene])
+
+  const visibleCases = useMemo(
+    () => filteredCases.slice(0, visibleCount),
+    [filteredCases, visibleCount],
+  )
+
+  const hasMore = visibleCases.length < filteredCases.length
+
+  const loadMore = useCallback(() => {
+    setVisibleCount((prev) => prev + BATCH_SIZE)
+  }, [])
+
+  useEffect(() => {
+    if (!hasMore) return
+    const sentinel = sentinelRef.current
+    if (!sentinel) return
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) loadMore()
+      },
+      { rootMargin: '400px' },
+    )
+
+    observer.observe(sentinel)
+    return () => observer.disconnect()
+  }, [hasMore, loadMore])
+
+  const handleCopyPrompt = (text: string) => {
+    navigator.clipboard.writeText(text).then(
+      () => showToast('Prompt 已复制'),
+      () => showToast('复制失败', 'error'),
+    )
+  }
+
+  const handleOpenPreview = (caseItem: CaseRecord) => {
+    setPreviewCase(caseItem)
+    document.body.style.overflow = 'hidden'
+  }
+
+  const handleClosePreview = () => {
+    setPreviewCase(null)
+    document.body.style.overflow = ''
+  }
+
+  // 关闭弹窗的键盘事件
+  useEffect(() => {
+    if (!previewCase) return
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') handleClosePreview()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [previewCase])
+
+  if (loadState === 'loading') {
+    return (
+      <main data-home-main className="pb-48">
+        <div className="safe-area-x max-w-7xl mx-auto mt-6">
+          <div className="flex items-center justify-center py-20 text-gray-400">
+            <svg className="w-5 h-5 animate-spin mr-2" fill="none" viewBox="0 0 24 24">
+              <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+              <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            加载案例数据...
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  if (loadState === 'error') {
+    return (
+      <main data-home-main className="pb-48">
+        <div className="safe-area-x max-w-7xl mx-auto mt-6">
+          <div className="flex flex-col items-center justify-center py-20 text-gray-400 gap-3">
+            <span className="text-red-500">加载失败: {errorMessage}</span>
+            <button
+              onClick={() => window.location.reload()}
+              className="px-4 py-2 rounded-lg bg-blue-500 text-white text-sm hover:bg-blue-600 transition-colors"
+            >
+              重试
+            </button>
+          </div>
+        </div>
+      </main>
+    )
+  }
+
+  return (
+    <>
+      <main data-home-main className="pb-48">
+        <div className="safe-area-x max-w-7xl mx-auto">
+          {/* Search */}
+          <div data-no-drag-select className="mt-6 mb-4 flex gap-3">
+            <div className="relative flex-1 z-10">
+              <svg
+                className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 dark:text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" />
+              </svg>
+              <input
+                value={caseSearchQuery}
+                onChange={(e) => setCaseSearchQuery(e.target.value)}
+                type="text"
+                placeholder="搜索案例、来源、Prompt..."
+                className="w-full pl-10 pr-4 py-2.5 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-white dark:bg-gray-900 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/30 focus:border-blue-400 transition"
+              />
+            </div>
+          </div>
+
+          {/* Filters */}
+          {styleLib && (
+            <CaseFilter
+              categories={styleLib.categories}
+              styles={styleLib.styles}
+              scenes={styleLib.scenes}
+              activeCategory={caseFilterCategory}
+              activeStyle={caseFilterStyle}
+              activeScene={caseFilterScene}
+              onCategoryChange={setCaseFilterCategory}
+              onStyleChange={setCaseFilterStyle}
+              onSceneChange={setCaseFilterScene}
+            />
+          )}
+
+          {/* Result bar */}
+          <div data-no-drag-select className="mb-4 flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
+            <span className="font-medium text-gray-700 dark:text-gray-300">{filteredCases.length}</span>
+            <span>个匹配案例</span>
+            <span className="text-xs text-gray-400">
+              (已加载 {visibleCases.length} 个)
+            </span>
+            <a
+              href="https://github.com/freestylefly/awesome-gpt-image-2"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-auto text-xs text-blue-500 hover:underline"
+            >
+              GitHub 数据源
+            </a>
+          </div>
+
+          {/* Grid — CSS columns for masonry-like layout */}
+          <div className="columns-1 sm:columns-2 lg:columns-3 gap-4 [&>*]:break-inside-avoid [&>*]:mb-4">
+            {visibleCases.map((c) => (
+              <CaseCard
+                key={c.id}
+                caseItem={c}
+                onCopyPrompt={handleCopyPrompt}
+                onOpenPreview={handleOpenPreview}
+              />
+            ))}
+          </div>
+
+          {/* Sentinel for infinite scroll */}
+          {hasMore && (
+            <div ref={sentinelRef} className="flex items-center justify-center py-8 text-gray-400 text-sm">
+              <svg className="w-4 h-4 animate-spin mr-2" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
+              加载更多...
+            </div>
+          )}
+
+          {filteredCases.length === 0 && (
+            <p className="mt-10 text-center text-sm text-gray-400">没有匹配的案例，试试调整筛选条件。</p>
+          )}
+        </div>
+      </main>
+
+      {/* Detail Preview Modal */}
+      {previewCase && (
+        <CasePreview
+          caseItem={previewCase}
+          onClose={handleClosePreview}
+          onCopyPrompt={handleCopyPrompt}
+        />
+      )}
+    </>
+  )
+}

--- a/src/components/CasePreview.tsx
+++ b/src/components/CasePreview.tsx
@@ -1,0 +1,170 @@
+import { useEffect, useState, useCallback } from 'react'
+import type { CaseRecord } from '../types'
+import { getImageUrl } from '../data/caseData'
+
+interface Props {
+  caseItem: CaseRecord
+  onClose: () => void
+  onCopyPrompt: (text: string) => void
+}
+
+export default function CasePreview({ caseItem, onClose, onCopyPrompt }: Props) {
+  const [lightboxOpen, setLightboxOpen] = useState(false)
+  const tags = [...new Set([...caseItem.styles, ...caseItem.scenes])].slice(0, 8)
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (lightboxOpen) {
+        if (e.key === 'Escape') setLightboxOpen(false)
+        return
+      }
+      if (e.key === 'Escape') onClose()
+    },
+    [lightboxOpen, onClose],
+  )
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [handleKeyDown])
+
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-black/70 backdrop-blur-sm p-4 sm:p-6"
+        role="presentation"
+        onMouseDown={(e) => {
+          if (e.target === e.currentTarget) onClose()
+        }}
+      >
+        <div
+          className="relative w-full max-w-4xl my-8 bg-white dark:bg-gray-900 rounded-2xl shadow-2xl overflow-hidden"
+          role="dialog"
+          aria-modal="true"
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute top-4 right-4 z-10 p-2 rounded-full bg-black/60 text-white hover:bg-black/80 transition-colors"
+            aria-label="关闭"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+
+          {/* Clickable image */}
+          <button
+            type="button"
+            onClick={() => setLightboxOpen(true)}
+            className="block w-full bg-gray-100 dark:bg-gray-950 cursor-zoom-in border-0 p-0"
+          >
+            <img
+              src={getImageUrl(caseItem.image)}
+              alt={caseItem.imageAlt}
+              className="w-full max-h-[55vh] object-contain"
+            />
+          </button>
+
+          <div className="p-5 sm:p-6">
+            <div className="flex flex-wrap gap-2 text-xs font-extrabold uppercase text-cyan-600 dark:text-cyan-400 mb-3">
+              <span>案例 {caseItem.id}</span>
+              <span>{caseItem.category}</span>
+            </div>
+
+            <h2 className="text-xl sm:text-2xl font-bold text-gray-900 dark:text-white mb-3">
+              {caseItem.title}
+            </h2>
+
+            <p className="text-sm text-gray-500 dark:text-gray-400 leading-relaxed mb-4">
+              {caseItem.promptPreview || caseItem.prompt.slice(0, 300)}
+            </p>
+
+            {tags.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 mb-5">
+                {tags.map((tag) => (
+                  <span
+                    key={`${caseItem.id}-${tag}`}
+                    className="px-2.5 py-1 rounded-full text-xs bg-gray-100 dark:bg-white/[0.07] text-gray-600 dark:text-gray-400"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-2 mb-6">
+              <button
+                type="button"
+                onClick={() => onCopyPrompt(caseItem.prompt)}
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/[0.1] bg-gray-50 dark:bg-white/[0.06] text-gray-700 dark:text-gray-300 text-sm font-bold hover:bg-gray-100 dark:hover:bg-white/[0.1] transition-colors"
+              >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+                复制 Prompt
+              </button>
+              <a
+                href={caseItem.githubUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/[0.1] bg-gray-50 dark:bg-white/[0.06] text-gray-700 dark:text-gray-300 text-sm font-bold hover:bg-gray-100 dark:hover:bg-white/[0.1] transition-colors"
+              >
+                GitHub 源文件
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                </svg>
+              </a>
+              {caseItem.sourceUrl && (
+                <a
+                  href={caseItem.sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-2 px-4 py-2 rounded-lg border border-gray-200 dark:border-white/[0.1] bg-gray-50 dark:bg-white/[0.06] text-gray-700 dark:text-gray-300 text-sm font-bold hover:bg-gray-100 dark:hover:bg-white/[0.1] transition-colors"
+                >
+                  来源
+                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+              )}
+            </div>
+
+            <div>
+              <h3 className="text-sm font-bold text-gray-700 dark:text-gray-300 mb-2">完整 Prompt</h3>
+              <pre className="p-4 rounded-xl bg-gray-50 dark:bg-gray-950 border border-gray-200 dark:border-white/[0.08] text-sm text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono leading-relaxed max-h-[400px] overflow-y-auto">
+                {caseItem.prompt}
+              </pre>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Lightbox */}
+      {lightboxOpen && (
+        <div
+          className="fixed inset-0 z-[60] bg-black/95 flex items-center justify-center p-4"
+          role="presentation"
+          onClick={() => setLightboxOpen(false)}
+        >
+          <button
+            type="button"
+            onClick={() => setLightboxOpen(false)}
+            className="absolute top-4 right-4 z-10 p-2 rounded-full bg-white/10 text-white hover:bg-white/20 transition-colors"
+            aria-label="关闭"
+          >
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <img
+            src={getImageUrl(caseItem.image)}
+            alt={caseItem.imageAlt}
+            className="max-w-full max-h-full object-contain rounded-lg"
+            onClick={(e) => e.stopPropagation()}
+          />
+        </div>
+      )}
+    </>
+  )
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -245,6 +245,13 @@ export default function Header() {
             </button>
             <button
               type="button"
+              onClick={() => setAppMode('cases')}
+              className={`px-4 py-1.5 rounded-lg text-sm transition-colors ${appMode === 'cases' ? 'bg-white dark:bg-white/10 text-gray-900 dark:text-white shadow-sm font-medium' : 'text-gray-500 hover:text-gray-800 dark:hover:text-gray-200'}`}
+            >
+              案例
+            </button>
+            <button
+              type="button"
               onClick={() => setAppMode('agent')}
               className={`px-4 py-1.5 rounded-lg text-sm transition-colors ${appMode === 'agent' ? 'bg-white dark:bg-white/10 text-gray-900 dark:text-white shadow-sm font-medium' : 'text-gray-500 hover:text-gray-800 dark:hover:text-gray-200'}`}
             >
@@ -308,13 +315,20 @@ export default function Header() {
           </div>
         </div>
         <div className={`safe-area-x sm:hidden overflow-hidden transition-all duration-300 ease-in-out ${appMode === 'gallery' && scrollDirection === 'down' ? 'max-h-0 opacity-0 pb-0' : 'max-h-20 opacity-100 pb-2'}`}>
-          <div className="grid grid-cols-2 gap-1 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-gray-100/70 dark:bg-white/[0.04] p-1 mx-2">
+          <div className="grid grid-cols-3 gap-1 rounded-xl border border-gray-200 dark:border-white/[0.08] bg-gray-100/70 dark:bg-white/[0.04] p-1 mx-2">
             <button
               type="button"
               onClick={() => setAppMode('gallery')}
               className={`px-4 py-1.5 rounded-lg text-sm transition-colors ${appMode === 'gallery' ? 'bg-white dark:bg-white/10 text-gray-900 dark:text-white shadow-sm font-medium' : 'text-gray-500 hover:text-gray-800 dark:hover:text-gray-200'}`}
             >
               画廊
+            </button>
+            <button
+              type="button"
+              onClick={() => setAppMode('cases')}
+              className={`px-4 py-1.5 rounded-lg text-sm transition-colors ${appMode === 'cases' ? 'bg-white dark:bg-white/10 text-gray-900 dark:text-white shadow-sm font-medium' : 'text-gray-500 hover:text-gray-800 dark:hover:text-gray-200'}`}
+            >
+              案例
             </button>
             <button
               type="button"

--- a/src/data/caseData.ts
+++ b/src/data/caseData.ts
@@ -1,0 +1,60 @@
+import type { CaseRecord, CaseStyleLibrary } from '../types'
+
+const CASES_URL = 'https://raw.githubusercontent.com/freestylefly/awesome-gpt-image-2/main/data/cases.json'
+const STYLE_LIBRARY_URL = 'https://raw.githubusercontent.com/freestylefly/awesome-gpt-image-2/main/data/style-library.json'
+const IMAGE_BASE = 'https://raw.githubusercontent.com/freestylefly/awesome-gpt-image-2/main/data/images'
+
+let casesCache: CaseRecord[] | null = null
+let styleLibraryCache: CaseStyleLibrary | null = null
+let fetchPromise: Promise<CaseRecord[]> | null = null
+let stylePromise: Promise<CaseStyleLibrary> | null = null
+
+export async function fetchCases(): Promise<CaseRecord[]> {
+  if (casesCache) return casesCache
+  if (fetchPromise) return fetchPromise
+
+  fetchPromise = fetch(CASES_URL)
+    .then((res) => {
+      if (!res.ok) throw new Error(`Failed to fetch cases: ${res.status}`)
+      return res.json()
+    })
+    .then((data) => {
+      casesCache = (data.cases as CaseRecord[]).map((c) => ({
+        ...c,
+        image: `${IMAGE_BASE}/${c.image.replace(/^\/images\//, '')}`,
+      }))
+      return casesCache
+    })
+    .catch((err) => {
+      fetchPromise = null
+      throw err
+    })
+
+  return fetchPromise
+}
+
+export async function fetchStyleLibrary(): Promise<CaseStyleLibrary> {
+  if (styleLibraryCache) return styleLibraryCache
+  if (stylePromise) return stylePromise
+
+  stylePromise = fetch(STYLE_LIBRARY_URL)
+    .then((res) => {
+      if (!res.ok) throw new Error(`Failed to fetch style library: ${res.status}`)
+      return res.json()
+    })
+    .then((data) => {
+      styleLibraryCache = data as CaseStyleLibrary
+      return styleLibraryCache
+    })
+    .catch((err) => {
+      stylePromise = null
+      throw err
+    })
+
+  return stylePromise
+}
+
+export function getImageUrl(imagePath: string): string {
+  if (imagePath.startsWith('http')) return imagePath
+  return `${IMAGE_BASE}/${imagePath.replace(/^\/images\//, '')}`
+}

--- a/src/store.ts
+++ b/src/store.ts
@@ -720,7 +720,7 @@ function mergePersistedState(persistedState: unknown, currentState: AppState): A
     typeof persisted.activeAgentConversationId === 'string' && (!hasPersistedAgentConversations || agentConversations.some((conversation) => conversation.id === persisted.activeAgentConversationId))
       ? persisted.activeAgentConversationId
       : agentConversations[0]?.id ?? null
-  const appMode = persisted.appMode === 'agent' ? 'agent' : 'gallery'
+  const appMode = persisted.appMode === 'agent' ? 'agent' : persisted.appMode === 'cases' ? 'cases' : 'gallery'
   const galleryInputDraft = settings.persistInputOnRestart
     ? normalizeAgentInputDraft(persisted.galleryInputDraft ?? {
         prompt: persisted.prompt,
@@ -857,6 +857,16 @@ interface AppState {
   streamPreviews: Record<string, string>
   streamPreviewSlots: Record<string, Record<string, string>>
   setTaskStreamPreview: (taskId: string, image?: string, requestIndex?: number) => void
+
+  // 案例筛选
+  caseSearchQuery: string
+  setCaseSearchQuery: (q: string) => void
+  caseFilterCategory: string | null
+  setCaseFilterCategory: (c: string | null) => void
+  caseFilterStyle: string | null
+  setCaseFilterStyle: (s: string | null) => void
+  caseFilterScene: string | null
+  setCaseFilterScene: (s: string | null) => void
 
   // 搜索和筛选
   searchQuery: string
@@ -1162,6 +1172,11 @@ export const useStore = create<AppState>()(
             agentEditingRoundId: null,
             ...(state.appMode === 'agent' ? restoreGalleryInputDraftState(galleryInputDraft) : {}),
           }))
+          return
+        }
+
+        if (appMode === 'cases') {
+          set({ appMode, selectedTaskIds: [], selectedFavoriteCollectionIds: [] })
           return
         }
 
@@ -1555,6 +1570,16 @@ export const useStore = create<AppState>()(
         }
       }),
       clearFavoriteCollectionSelection: () => set({ selectedFavoriteCollectionIds: [] }),
+
+      // Case filters
+      caseSearchQuery: '',
+      setCaseSearchQuery: (caseSearchQuery) => set({ caseSearchQuery }),
+      caseFilterCategory: null,
+      setCaseFilterCategory: (caseFilterCategory) => set({ caseFilterCategory }),
+      caseFilterStyle: null,
+      setCaseFilterStyle: (caseFilterStyle) => set({ caseFilterStyle }),
+      caseFilterScene: null,
+      setCaseFilterScene: (caseFilterScene) => set({ caseFilterScene }),
 
       // UI
       detailTaskId: null,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,7 @@
 // ===== 设置 =====
 
 export type ApiMode = 'images' | 'responses'
-export type AppMode = 'gallery' | 'agent'
+export type AppMode = 'gallery' | 'agent' | 'cases'
 export type ReferenceImageEditAction = 'ask' | 'replace-reference' | 'add-mask'
 export const ZIP_DOWNLOAD_ROUTE_VALUES = [
   'task-selection',
@@ -435,4 +435,61 @@ export interface ExportData {
     height?: number
     thumbnailVersion?: number
   }>
+}
+
+// ===== 提示词案例 =====
+
+export interface CaseRecord {
+  id: number
+  title: string
+  image: string
+  imageAlt: string
+  sourceLabel: string
+  sourceUrl: string
+  prompt: string
+  promptPreview: string
+  category: string
+  styles: string[]
+  scenes: string[]
+  featured: boolean
+  githubUrl: string
+}
+
+export interface CaseStyleLibrary {
+  version: number
+  repository: string
+  tagLabels: Record<string, { en: string; zh: string }>
+  categories: CaseCategoryDef[]
+  styles: CaseFilterDef[]
+  scenes: CaseFilterDef[]
+  templates: CaseTemplateDef[]
+}
+
+export interface CaseCategoryDef {
+  id: string
+  value: string
+  title: { en: string; zh: string }
+  description: { en: string; zh: string }
+}
+
+export interface CaseFilterDef {
+  id: string
+  value: string
+  title: { en: string; zh: string }
+  keywords: string[]
+}
+
+export interface CaseTemplateDef {
+  id: string
+  anchor: string
+  title: { en: string; zh: string }
+  description: { en: string; zh: string }
+  category: string
+  styles: string[]
+  scenes: string[]
+  tags: string[]
+  useWhen: { en: string; zh: string }
+  guidance: { en: string[]; zh: string[] }
+  pitfalls: { en: string[]; zh: string[] }
+  exampleCases: number[]
 }


### PR DESCRIPTION
Adds a third app mode 'cases' alongside gallery and agent, providing a prompt inspiration library. Case data is fetched at runtime from the freestylefly/awesome-gpt-image-2 repository.

New components:
- CaseGallery: main container with search, filtering, masonry layout, infinite scroll (IntersectionObserver), and loading/error states
- CaseCard: card component with image, thumb, tags, and action buttons (copy prompt, view details, GitHub source)
- CaseFilter: filter bar with category, style, and scene dimensions
- CasePreview: detail modal with full image, lightbox, and complete prompt

New data module:
- src/data/caseData.ts: remote JSON fetcher with in-memory cache and request dedup; image URL builder

Modified files:
- src/types.ts: add 'cases' to AppMode; add CaseRecord, CaseStyleLibrary, CaseCategoryDef, CaseFilterDef, CaseTemplateDef interfaces
- src/store.ts: add caseSearchQuery/caseFilterCategory/caseFilterStyle/ caseFilterScene states and setters; add 'cases' route in setAppMode; restore 'cases' mode from persisted state
- src/App.tsx: import CaseGallery; render for appMode === 'cases'
- src/components/Header.tsx: add '案例' button in desktop (3-btn row) and mobile (grid-cols-3) mode toggles