### PR TITLE
feat: 分离Agent对话配置与图像生成配置

### DIFF
--- a/src/components/HelpModal.tsx
+++ b/src/components/HelpModal.tsx
@@ -68,7 +68,7 @@ export default function HelpModal({ appMode, isFavoriteCollectionOverview = fals
                 <div className="space-y-4">
                   <ul className="list-disc pl-4 space-y-2">
                     <li>需要使用 Responses API 配置。</li>
-                    <li>如需 Agent 搜索互联网或读取 URL 内容，可在设置的 Agent 配置中开启“网络搜索”。</li>
+                    <li>如需 Agent 搜索互联网或读取 URL 内容，可在设置的 API 配置中开启“网络搜索”。</li>
                     <li>输入 <strong className="text-blue-500 dark:text-blue-400 font-medium">@</strong> 可引用参考图或前面轮次生成的图片；Agent 也会自行参考上下文中的图片。</li>
                     <li>编辑某轮消息重新发送，或重新生成某轮消息，会产生可切换的分支。</li>
                     <li>生成的图片会同步到画廊；删除对话默认不会删除画廊中的任务。</li>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -586,6 +586,22 @@ export default function SettingsModal() {
     url.search = ''
     url.hash = ''
 
+    // 构建图像配置的 settings JSON
+    const imageSettings: Record<string, unknown> = {}
+    if (draft.agentImageGenerationBackend === 'image-api') {
+      imageSettings.agentImageGenerationBackend = 'image-api'
+      const imageExport: ApiProfile = {
+        ...draft.imageApiProfile,
+        apiKey: options.includeApiKey ? draft.imageApiProfile.apiKey : '',
+      }
+      if (!options.includeApiKey) {
+        if (options.useNewApiAddress) imageExport.baseUrl = '{address}'
+        if (options.useNewApiKey) imageExport.apiKey = '{key}'
+        if (options.useNewApiModel) imageExport.model = '{model}'
+      }
+      imageSettings.imageApiProfile = imageExport
+    }
+
     if (profile.provider === 'openai') {
       const baseUrl = profile.baseUrl.trim() || DEFAULT_SETTINGS.baseUrl
       url.searchParams.set('apiUrl', options.useNewApiAddress && !options.includeApiKey ? '{address}' : normalizeBaseUrl(baseUrl))
@@ -601,6 +617,11 @@ export default function SettingsModal() {
       if (profile.codexCli) url.searchParams.set('codexCli', 'true')
       if (profile.streamImages !== DEFAULT_SETTINGS.streamImages) url.searchParams.set('streamImages', String(Boolean(profile.streamImages)))
       if (profile.streamPartialImages !== DEFAULT_STREAM_PARTIAL_IMAGES) url.searchParams.set('streamPartialImages', String(normalizeStreamPartialImages(profile.streamPartialImages)))
+
+      // 追加图像配置
+      if (Object.keys(imageSettings).length > 0) {
+        url.searchParams.set('settings', JSON.stringify(imageSettings))
+      }
 
       let result = url.toString()
       if (!options.includeApiKey) {
@@ -624,6 +645,7 @@ export default function SettingsModal() {
     url.searchParams.set('settings', JSON.stringify({
       customProviders: provider ? [provider] : [],
       profiles: [importProfile],
+      ...imageSettings,
     }))
 
     let result = url.toString()

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -205,6 +205,18 @@ function isProfileApiProxyEligible(settings: AppSettings, profile: ApiProfile) {
   return !isAsyncCustomProvider(customProvider)
 }
 
+function toAgentResponsesProfile(profile: ApiProfile): ApiProfile {
+  const switched = switchApiProfileProvider(profile, 'openai')
+  return {
+    ...switched,
+    id: profile.id,
+    name: profile.name,
+    apiKey: profile.apiKey,
+    apiMode: 'responses',
+    model: profile.provider === 'openai' && profile.apiMode === 'responses' ? profile.model : DEFAULT_RESPONSES_MODEL,
+  }
+}
+
 const CUSTOM_PROVIDER_LLM_PROMPT = `# 角色
 你是 API 文档解析助手。你的任务是根据用户提供的图像生成 API 文档，生成本应用可导入的自定义服务商配置 JSON。
 
@@ -394,20 +406,13 @@ export default function SettingsModal() {
     })),
   ]
 
-  const providerOptions = [
+  const agentImageProviderOptions = [
     { label: '创建自定义服务商', value: ADD_CUSTOM_PROVIDER_VALUE, variant: 'action' as const },
-    ...unorderedProviderOptions.sort((a, b) => {
-      const aIndex = providerOrder.indexOf(String(a.value))
-      const bIndex = providerOrder.indexOf(String(b.value))
-      const validA = aIndex !== -1 ? aIndex : defaultProviderOrder.indexOf(String(a.value))
-      const validB = bIndex !== -1 ? bIndex : defaultProviderOrder.indexOf(String(b.value))
-      return validA - validB
-    })
+    ...unorderedProviderOptions,
   ]
-
-  const agentImageProviderOptions = unorderedProviderOptions
-    .map(({ label, value }) => ({ label, value }))
     .sort((a, b) => {
+      if (a.value === ADD_CUSTOM_PROVIDER_VALUE) return -1
+      if (b.value === ADD_CUSTOM_PROVIDER_VALUE) return 1
       const aIndex = providerOrder.indexOf(String(a.value))
       const bIndex = providerOrder.indexOf(String(b.value))
       const validA = aIndex !== -1 ? aIndex : defaultProviderOrder.indexOf(String(a.value))
@@ -444,6 +449,7 @@ export default function SettingsModal() {
       ...displaySettings,
       profiles: displaySettings.profiles.map((profile) => ({
         ...profile,
+        ...(profile.id === displaySettings.activeProfileId ? toAgentResponsesProfile(profile) : profile),
         apiProxy: isProfileApiProxyEligible(displaySettings, profile) && apiProxyAvailable
           ? (apiProxyLocked || profile.apiProxy)
           : false,
@@ -459,7 +465,8 @@ export default function SettingsModal() {
   }, [activeProfile.id, activeProfile.timeout])
 
   useEffect(() => {
-    if (showSettings && settingsTabRequest) setActiveTab(settingsTabRequest)
+    if (!showSettings || !settingsTabRequest) return
+    setActiveTab(settingsTabRequest)
   }, [settingsTabRequest, showSettings])
 
   const updateProfileMenuMaxHeight = useCallback(() => {
@@ -658,7 +665,7 @@ export default function SettingsModal() {
 
   const getDraftWithActiveProfilePatch = (patch: Partial<ApiProfile>) => ({
       ...draft,
-      profiles: draft.profiles.map((profile) => profile.id === activeProfile.id ? { ...profile, ...patch } : profile),
+      profiles: draft.profiles.map((profile) => profile.id === activeProfile.id ? { ...profile, ...patch, apiMode: 'responses' as const } : profile),
     })
 
   const updateActiveProfile = (patch: Partial<ApiProfile>, commit = false) => {
@@ -687,6 +694,14 @@ export default function SettingsModal() {
   }
 
   const handleAgentImageProviderChange = (provider: string | number) => {
+    if (provider === ADD_CUSTOM_PROVIDER_VALUE) {
+      setEditingCustomProviderId(null)
+      setCustomProviderForm(createDefaultCustomProviderForm())
+      setShowCustomProviderImport(true)
+      setCustomProviderImportError(null)
+      return
+    }
+
     const providerId = String(provider)
     const customProvider = draft.customProviders.find((item) => item.id === providerId)
     const nextProfile = switchApiProfileProvider(draft.agentImageApiProfile, providerId, customProvider)
@@ -806,7 +821,7 @@ export default function SettingsModal() {
   const createNewProfile = () => {
     if (defaultConfigOnly) return
     setReusedTaskApiProfile(null)
-    const profile = createDefaultOpenAIProfile({ id: newId('openai'), name: '新配置' })
+    const profile = toAgentResponsesProfile(createDefaultOpenAIProfile({ id: newId('openai'), name: '新配置', apiMode: 'responses' }))
     const nextDraft = normalizeSettings({ 
         ...draft, 
         profiles: [...draft.profiles, profile],
@@ -821,9 +836,10 @@ export default function SettingsModal() {
     setReusedTaskApiProfile(null)
     setDuplicateProfileTooltipVisible(false)
     const profile: ApiProfile = {
-      ...activeProfile,
+      ...toAgentResponsesProfile(activeProfile),
       id: newId(activeProfile.provider === 'openai' ? 'openai' : 'profile'),
       name: `${activeProfile.name}（复制）`,
+      apiMode: 'responses',
     }
     const nextDraft = normalizeSettings({
       ...draft,
@@ -837,7 +853,11 @@ export default function SettingsModal() {
   const switchProfile = (id: string) => {
     if (defaultConfigOnly) return
     setReusedTaskApiProfile(null)
-    const nextDraft = normalizeSettings({ ...draft, activeProfileId: id })
+    const nextDraft = normalizeSettings({
+      ...draft,
+      profiles: draft.profiles.map((profile) => profile.id === id ? toAgentResponsesProfile(profile) : profile),
+      activeProfileId: id,
+    })
     commitSettings(nextDraft)
     setShowProfileMenu(false)
   }
@@ -991,40 +1011,6 @@ export default function SettingsModal() {
     commitSettings(nextDraft)
   }
 
-  const handleProviderReorder = (sourceValue: string | number, targetValue: string | number, position: 'before' | 'after' | null) => {
-    const currentOrder = draft.providerOrder || ['openai', 'fal', ...draft.customProviders.map(p => p.id)]
-    const sourceIndex = currentOrder.indexOf(String(sourceValue))
-    const targetIndex = currentOrder.indexOf(String(targetValue))
-    if (sourceIndex < 0 || targetIndex < 0) return
-
-    const newOrder = [...currentOrder]
-    const [removed] = newOrder.splice(sourceIndex, 1)
-
-    let newTargetIndex = targetIndex
-    if (position === 'after') newTargetIndex++
-    if (sourceIndex < targetIndex) newTargetIndex--
-
-    newOrder.splice(newTargetIndex, 0, removed)
-
-    const nextDraft = normalizeSettings({ ...draft, providerOrder: newOrder })
-    commitSettings(nextDraft)
-  }
-
-  const handleProviderTypeChange = (value: string | number) => {
-    if (defaultConfigOnly) return
-    if (value === ADD_CUSTOM_PROVIDER_VALUE) {
-      setEditingCustomProviderId(null)
-      setCustomProviderForm(createDefaultCustomProviderForm())
-      setShowCustomProviderImport(true)
-      setCustomProviderImportError(null)
-      return
-    }
-
-    const provider = String(value) as ApiProfile['provider']
-    const customProvider = draft.customProviders.find((item) => item.id === provider)
-    updateActiveProfile(switchApiProfileProvider(activeProfile, provider, customProvider), true)
-  }
-
   const updateCustomProviderForm = (patch: Partial<CustomProviderForm>) => {
     setCustomProviderForm((current) => ({ ...current, ...patch }))
     setCustomProviderImportError(null)
@@ -1103,6 +1089,9 @@ export default function SettingsModal() {
       profiles: draft.profiles.map((profile) =>
         profile.provider === providerId ? switchApiProfileProvider(profile, 'openai') : profile,
       ),
+      agentImageApiProfile: draft.agentImageApiProfile.provider === providerId
+        ? switchApiProfileProvider(draft.agentImageApiProfile, 'openai')
+        : draft.agentImageApiProfile,
     })
     commitSettings(nextDraft)
     showToast('服务商已删除', 'success')
@@ -1137,11 +1126,12 @@ export default function SettingsModal() {
               ...mergedDraft,
               profiles: mergedDraft.profiles
                 .filter((profile) => profile.id === activeProfile.id || profile.id !== importedProfile.id)
-                .map((profile) => profile.id === activeProfile.id ? { ...importedProfile, id: activeProfile.id } : profile),
+                .map((profile) => profile.id === activeProfile.id ? toAgentResponsesProfile({ ...importedProfile, id: activeProfile.id }) : profile),
               activeProfileId: activeProfile.id,
             })
           : normalizeSettings({
               ...mergedDraft,
+              profiles: mergedDraft.profiles.map((profile) => profile.id === importedProfile.id ? toAgentResponsesProfile(profile) : profile),
               activeProfileId: importedProfile.id,
             })
         setDraft(nextDraft)
@@ -1223,17 +1213,6 @@ export default function SettingsModal() {
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6v6l4 2m6-2a10 10 0 11-20 0 10 10 0 0120 0z" />
                 </svg>
                 习惯配置
-              </button>
-              <button
-                onClick={() => setActiveTab('agent')}
-                className={`whitespace-nowrap flex-shrink-0 flex items-center gap-2.5 px-3 py-2.5 text-sm rounded-xl transition-colors ${activeTab === 'agent' ? 'bg-white dark:bg-white/[0.08] shadow-sm text-blue-600 dark:text-blue-400 font-medium' : 'text-gray-600 dark:text-gray-400 hover:bg-gray-100/80 dark:hover:bg-white/[0.04]'}`}
-              >
-                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8V4H8" />
-                  <rect width="16" height="12" x="4" y="8" rx="2" strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} />
-                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M2 14h2M20 14h2M15 13v2M9 13v2" />
-                </svg>
-                Agent 配置
               </button>
               <button
                 onClick={() => setActiveTab('data')}
@@ -1462,183 +1441,6 @@ export default function SettingsModal() {
                 </div>
               </div>
             )}
-
-            {activeTab === 'agent' && (
-              <div className="space-y-4">
-                <div className="block">
-                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">图像生成方式</span>
-                  <Select
-                    value={draft.agentImageGenerationBackend}
-                    onChange={(value) => commitSettings({ ...draft, agentImageGenerationBackend: value === 'image-api' ? 'image-api' : 'native' })}
-                    options={[
-                      { label: 'Responses 原生 image_generation', value: 'native' },
-                      { label: '独立 Image API 配置', value: 'image-api' },
-                    ]}
-                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                  />
-                  <div data-selectable-text className="mt-1.5 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
-                    原生模式要求当前 Responses 模型支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code> 工具；独立 Image API 模式会让 Agent 调用客户端函数工具，再由下方图像配置生成图片。
-                  </div>
-                </div>
-                {draft.agentImageGenerationBackend === 'image-api' && (
-                  <div className="space-y-4 rounded-2xl border border-gray-200/70 bg-gray-50/70 p-4 dark:border-white/[0.08] dark:bg-white/[0.03]">
-                    <div>
-                      <div className="text-sm font-medium text-gray-700 dark:text-gray-200">Agent 图像生成配置</div>
-                      <div data-selectable-text className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
-                        这套配置只用于 Agent 工具生成图片；对话仍使用 API 配置页里当前的 Responses 配置。
-                      </div>
-                    </div>
-                    <div className="block">
-                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
-                      <Select
-                        value={agentImageProfile.provider}
-                        onChange={handleAgentImageProviderChange}
-                        options={agentImageProviderOptions}
-                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                      />
-                    </div>
-                    {agentImageProviderUsesApiUrl && (
-                      <label className="block">
-                        <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API URL</span>
-                        <input
-                          value={agentImageProfile.baseUrl}
-                          onChange={(e) => updateAgentImageProfile({ baseUrl: e.target.value })}
-                          onBlur={(e) => updateAgentImageProfile({ baseUrl: e.target.value }, true)}
-                          type="text"
-                          disabled={agentImageApiProxyEnabled}
-                          placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
-                          className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${agentImageApiProxyEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
-                        />
-                        {agentImageApiProxyEnabled && (
-                          <div data-selectable-text className="mt-1.5 text-xs text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</div>
-                        )}
-                      </label>
-                    )}
-                    {apiProxyAvailable && agentImageProviderIsOpenAICompatible && !agentImageCustomProviderAsync && (
-                      <div className="block">
-                        <div className="mb-1.5 flex items-center justify-between">
-                          <span className="block text-sm text-gray-600 dark:text-gray-300">API 代理</span>
-                          <button
-                            type="button"
-                            onClick={() => {
-                              if (!apiProxyLocked) updateAgentImageProfile({ apiProxy: !agentImageProfile.apiProxy }, true)
-                            }}
-                            disabled={apiProxyLocked}
-                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageApiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
-                            role="switch"
-                            aria-checked={agentImageApiProxyChecked}
-                            aria-label="Agent 图像生成 API 代理"
-                          >
-                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageApiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
-                          </button>
-                        </div>
-                        <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                          {apiProxyLocked ? '部署端已锁定代理开启，请求经服务器转发到上游 API。' : '开启后图片生成请求经服务器转发到上游 API，可绕过浏览器跨域限制。'}
-                        </div>
-                      </div>
-                    )}
-                    <label className="block">
-                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API Key</span>
-                      <input
-                        value={agentImageProfile.apiKey}
-                        onChange={(e) => updateAgentImageProfile({ apiKey: e.target.value })}
-                        onBlur={(e) => updateAgentImageProfile({ apiKey: e.target.value }, true)}
-                        type={showApiKey ? 'text' : 'password'}
-                        placeholder={agentImageProfile.provider === 'fal' ? 'FAL_KEY' : 'sk-...'}
-                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                      />
-                    </label>
-                    <label className="block">
-                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">模型 ID</span>
-                      <input
-                        value={agentImageProfile.model}
-                        onChange={(e) => updateAgentImageProfile({ model: e.target.value })}
-                        onBlur={(e) => updateAgentImageProfile({ model: e.target.value }, true)}
-                        type="text"
-                        placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_MODEL : DEFAULT_IMAGES_MODEL}
-                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                      />
-                      <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                        {agentImageCustomProvider ? <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{agentImageCustomProvider.name}</code>。</> : <>Images API 通常使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_IMAGES_MODEL}</code>。</>}
-                      </div>
-                    </label>
-                    {agentImageProviderIsOpenAICompatible && (
-                      <div className="block">
-                        <div className="mb-1.5 flex items-center justify-between">
-                          <span className="block text-sm text-gray-600 dark:text-gray-300">返回 Base64 图片数据</span>
-                          <button
-                            type="button"
-                            onClick={() => updateAgentImageProfile({ responseFormatB64Json: !agentImageProfile.responseFormatB64Json }, true)}
-                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageProfile.responseFormatB64Json ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
-                            role="switch"
-                            aria-checked={!!agentImageProfile.responseFormatB64Json}
-                            aria-label="Agent 图像生成返回 Base64 图片数据"
-                          >
-                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageProfile.responseFormatB64Json ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
-                          </button>
-                        </div>
-                        <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                          开启后在图片生成请求体中追加 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">response_format: b64_json</code>。
-                        </div>
-                      </div>
-                    )}
-                    {agentImageProviderIsOpenAICompatible && (
-                      <label className="block">
-                        <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求超时 (秒)</span>
-                        <input
-                          value={agentImageProfile.timeout}
-                          onChange={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || agentImageProfile.timeout })}
-                          onBlur={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || DEFAULT_SETTINGS.timeout }, true)}
-                          type="number"
-                          min={10}
-                          max={600}
-                          className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                        />
-                      </label>
-                    )}
-                  </div>
-                )}
-                <label className="block">
-                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">最大工具调用轮数</span>
-                  <input
-                    value={agentMaxToolRoundsInput}
-                    onChange={(e) => setAgentMaxToolRoundsInput(e.target.value)}
-                    onBlur={commitAgentMaxToolRounds}
-                    type="number"
-                    min={1}
-                    max={50}
-                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                  />
-                  <div data-selectable-text className="mt-1.5 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
-                    默认 15。用于限制 Agent 连续调用工具时的最大轮数，防止无限循环。
-                  </div>
-                </label>
-                <div className="block">
-                  <div className="mb-1 flex items-center justify-between gap-3">
-                    <span className="block text-sm text-gray-600 dark:text-gray-300">网络搜索</span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        const agentMaxToolRounds = agentMaxToolRoundsInput.trim() === ''
-                          ? DEFAULT_AGENT_MAX_TOOL_ROUNDS
-                          : normalizeAgentMaxToolRounds(agentMaxToolRoundsInput, draft.agentMaxToolRounds)
-                        setAgentMaxToolRoundsInput(String(agentMaxToolRounds))
-                        commitSettings({ ...draft, agentMaxToolRounds, agentWebSearch: !draft.agentWebSearch })
-                      }}
-                      className={`relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors ${draft.agentWebSearch ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
-                      role="switch"
-                      aria-checked={draft.agentWebSearch}
-                      aria-label="网络搜索"
-                    >
-                      <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${draft.agentWebSearch ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
-                    </button>
-                  </div>
-                  <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                    启用 Responses API 的 <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[10px] dark:bg-white/[0.06]">web_search</code> 工具。模型每次调用此工具会产生少量固定价格的额外计费。
-                  </div>
-                </div>
-              </div>
-            )}
             
             {activeTab === 'api' && (
               <div className="space-y-4">
@@ -1825,7 +1627,6 @@ export default function SettingsModal() {
                   </div>
                 </div>
 
-              {/* 1. 配置名称 */}
               <label className="block">
                 <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">配置名称</span>
                 <input
@@ -1837,265 +1638,341 @@ export default function SettingsModal() {
                 />
               </label>
 
-              {/* 2. 服务商类型 */}
-              <div className="block">
-                <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
-                <Select
-                  value={activeProfile.provider}
-                  onChange={handleProviderTypeChange}
-                  onReorder={handleProviderReorder}
-                  options={providerOptions}
-                  disabled={defaultConfigOnly}
-                  className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                />
-              </div>
-
-              {/* 3. API URL */}
-              {activeProviderUsesApiUrl && (
-                <label className="block">
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <span className="block text-sm text-gray-600 dark:text-gray-300">API URL</span>
+              <div className="space-y-4 rounded-2xl border border-gray-200/70 bg-gray-50/70 p-4 dark:border-white/[0.08] dark:bg-white/[0.03]">
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200">Agent 配置</div>
+                  <div data-selectable-text className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
+                    当前配置用于 Agent 对话请求。这里固定使用 Responses API；是否具备原生图像生成能力由下方图片生成方式决定。
                   </div>
-                  <input
-                    value={activeProfile.baseUrl}
-                    onChange={(e) => updateActiveProfile({ baseUrl: e.target.value })}
-                    onBlur={(e) => commitActiveProfilePatch({ baseUrl: e.target.value })}
-                    type="text"
-                    disabled={apiProxyEnabled}
-                    placeholder={activeProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
-                    className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${apiProxyEnabled ? 'opacity-50 cursor-not-allowed' : ''}`}
-                  />
-                  <div data-selectable-text className="mt-1.5 min-h-[22px] flex items-center text-xs text-gray-500 dark:text-gray-500">
-                    {apiProxyEnabled ? (
-                      <span className="text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</span>
-                    ) : activeProfile.provider === 'fal' ? (
-                      <span>默认使用 <code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">{DEFAULT_FAL_BASE_URL}</code>；填写自定义地址时将作为 fal.ai 代理 URL。</span>
-                    ) : (
-                      <span>支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiUrl=</code></span>
-                    )}
-                  </div>
-                </label>
-              )}
-
-              {/* 4. API 代理（紧跟 URL） */}
-              {apiProxyAvailable && activeProviderIsOpenAICompatible && !activeCustomProviderAsync && (
+                </div>
                 <div className="block">
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <span className="block text-sm text-gray-600 dark:text-gray-300">API 代理</span>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        if (!apiProxyLocked) updateActiveProfile({ apiProxy: !activeProfile.apiProxy }, true)
-                      }}
-                      disabled={apiProxyLocked}
-                      className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${apiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
-                      role="switch"
-                      aria-checked={apiProxyChecked}
-                      aria-label="API 代理"
-                    >
-                      <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${apiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
-                    </button>
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
+                  <div className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200">
+                    OpenAI 兼容接口
                   </div>
-                  <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                    {apiProxyLocked ? '部署端已锁定代理开启，请求经服务器转发到上游 API，上方 URL 设置将失效。' : '开启后请求经服务器转发到上游 API，可绕过浏览器跨域限制，上方 URL 设置将失效。'}
-                  </div>
-                </div>
-              )}
-
-              {/* 5. API Key */}
-              <div className="block">
-                <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API Key</span>
-                <div className="relative">
-                  <input
-                    value={activeProfile.apiKey}
-                    onChange={(e) => updateActiveProfile({ apiKey: e.target.value })}
-                    onBlur={(e) => commitActiveProfilePatch({ apiKey: e.target.value })}
-                    type={showApiKey ? 'text' : 'password'}
-                    placeholder={activeProfile.provider === 'fal' ? 'FAL_KEY' : 'sk-...'}
-                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 pr-10 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => setShowApiKey((v) => !v)}
-                    className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 transition-colors"
-                    tabIndex={-1}
-                  >
-                    {showApiKey ? (
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
-                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
-                        <circle cx="12" cy="12" r="3" />
-                      </svg>
-                    ) : (
-                      <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
-                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
-                        <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
-                        <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
-                        <line x1="1" y1="1" x2="23" y2="23" />
-                      </svg>
-                    )}
-                  </button>
-                </div>
-                <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                  支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiKey=</code>
-                </div>
-              </div>
-
-              {/* 6. API 接口（Images/Responses） */}
-              {activeProfile.provider === 'openai' && (
-                <div className="block">
-                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API 接口</span>
-                  <Select
-                    value={activeProfile.apiMode ?? DEFAULT_SETTINGS.apiMode}
-                    onChange={(value) => {
-                      const apiMode = value as AppSettings['apiMode']
-                      const nextModel =
-                        activeProfile.model === DEFAULT_IMAGES_MODEL || activeProfile.model === DEFAULT_RESPONSES_MODEL
-                          ? getDefaultModelForMode(apiMode)
-                          : activeProfile.model
-                      updateActiveProfile({ apiMode, model: nextModel }, true)
-                    }}
-                    options={[
-                      { label: 'Images API (/v1/images)', value: 'images' },
-                      { label: 'Responses API (/v1/responses)', value: 'responses' },
-                    ]}
-                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                  />
                   <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                    支持通过查询参数覆盖：<code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">apiMode=images</code> 或 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">apiMode=responses</code>。
+                    Agent 对话固定使用 OpenAI-compatible Responses API；其他图片服务商请在下方“独立 Images API”中配置。
                   </div>
                 </div>
-              )}
-
-              {/* 7. 模型 ID（紧跟接口选择） */}
-              <label className="block">
-                <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">
-                  模型 ID
-                </span>
-                <input
-                  value={activeProfile.model}
-                  onChange={(e) => updateActiveProfile({ model: e.target.value })}
-                  onBlur={(e) => commitActiveProfilePatch({ model: e.target.value })}
-                  type="text"
-                  placeholder={activeProfile.provider === 'fal' ? DEFAULT_FAL_MODEL : getDefaultModelForMode(activeProfile.apiMode ?? DEFAULT_SETTINGS.apiMode)}
-                  className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
-                />
-                <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                  {activeProfile.provider === 'fal' ? (
-                    <>当前适配 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_FAL_MODEL}</code>。</>
-                  ) : activeCustomProvider ? (
-                    <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{activeCustomProvider.name}</code>。</>
-                  ) : (activeProfile.apiMode ?? DEFAULT_SETTINGS.apiMode) === 'responses' ? (
-                    <>Responses API 需要使用支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code> 工具的文本模型，例如 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_RESPONSES_MODEL}</code>。</>
-                  ) : (
-                    <>Images API 需要使用 GPT Image 模型，例如 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_IMAGES_MODEL}</code>。</>
-                  )}
-                  {activeProfile.provider === 'openai' && (
-                    <>支持通过查询参数覆盖：<code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">?model=</code>。</>
-                  )}
-                </div>
-              </label>
-
-              {/* 8. 流式传输 + 中间步骤图像数 */}
-              {activeProfile.provider === 'openai' && (
-                <div className="block space-y-3">
-                  <div>
-                    <div className="mb-1.5 flex items-center justify-between gap-3">
-                      <span className="block text-sm text-gray-600 dark:text-gray-300">流式传输</span>
+                {activeProviderUsesApiUrl && (
+                  <label className="block">
+                    <div className="mb-1.5 flex items-center justify-between">
+                      <span className="block text-sm text-gray-600 dark:text-gray-300">API URL</span>
+                    </div>
+                    <input
+                      value={activeProfile.baseUrl}
+                      onChange={(e) => updateActiveProfile({ baseUrl: e.target.value })}
+                      onBlur={(e) => commitActiveProfilePatch({ baseUrl: e.target.value })}
+                      type="text"
+                      disabled={apiProxyEnabled}
+                      placeholder={DEFAULT_SETTINGS.baseUrl}
+                      className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${apiProxyEnabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    />
+                    <div data-selectable-text className="mt-1.5 min-h-[22px] flex items-center text-xs text-gray-500 dark:text-gray-500">
+                      {apiProxyEnabled ? (
+                        <span className="text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</span>
+                      ) : (
+                        <span>支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiUrl=</code></span>
+                      )}
+                    </div>
+                  </label>
+                )}
+                {apiProxyAvailable && activeProviderIsOpenAICompatible && !activeCustomProviderAsync && (
+                  <div className="block">
+                    <div className="mb-1.5 flex items-center justify-between">
+                      <span className="block text-sm text-gray-600 dark:text-gray-300">API 代理</span>
                       <button
                         type="button"
-                        onClick={() => updateActiveProfile({ streamImages: !activeProfile.streamImages }, true)}
-                        className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${activeProfile.streamImages ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+                        onClick={() => {
+                          if (!apiProxyLocked) updateActiveProfile({ apiProxy: !activeProfile.apiProxy }, true)
+                        }}
+                        disabled={apiProxyLocked}
+                        className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${apiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
                         role="switch"
-                        aria-checked={!!activeProfile.streamImages}
-                        aria-label="流式传输"
+                        aria-checked={apiProxyChecked}
+                        aria-label="API 代理"
                       >
-                        <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${activeProfile.streamImages ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                        <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${apiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
                       </button>
                     </div>
                     <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                      开启后请求以流式传输，并非所有服务商和网关都支持此功能。官方接口在流式模式下不发送心跳，需要配合请求中间步骤图像来维持连接，避免超时断开。官方接口仅支持单图流式传输，因此数量大于 1 时会将多图生成拆分为并发单图。
+                      {apiProxyLocked ? '部署端已锁定代理开启，请求经服务器转发到上游 API，上方 URL 设置将失效。' : '开启后请求经服务器转发到上游 API，可绕过浏览器跨域限制，上方 URL 设置将失效。'}
                     </div>
                   </div>
-                  <label className={`block ${activeProfile.streamImages ? '' : 'opacity-60'}`}>
-                    <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求中间步骤图像数</span>
-                    <Select
-                      value={normalizeStreamPartialImages(activeProfile.streamPartialImages)}
-                      onChange={(value) => updateActiveProfile({ streamPartialImages: normalizeStreamPartialImages(value) }, true)}
-                      disabled={!activeProfile.streamImages}
-                      options={[
-                        { label: '0，不请求', value: 0 },
-                        { label: '1 张', value: 1 },
-                        { label: '2 张', value: 2 },
-                        { label: '3 张', value: 3 },
-                      ]}
-                      className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                )}
+                <div className="block">
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API Key</span>
+                  <div className="relative">
+                    <input
+                      value={activeProfile.apiKey}
+                      onChange={(e) => updateActiveProfile({ apiKey: e.target.value })}
+                      onBlur={(e) => commitActiveProfilePatch({ apiKey: e.target.value })}
+                      type={showApiKey ? 'text' : 'password'}
+                      placeholder="sk-..."
+                      className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 pr-10 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                     />
-                    <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                      对应 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">partial_images</code> 参数（0-3）。建议设为 2 或 3 以避免长时间生成时连接超时断开。实际返回的每张中间图像会产生少量额外计费。设为 0 时不请求中间步骤图像，连接可能因无数据传输而被断开。
-                    </div>
-                  </label>
-                </div>
-              )}
-
-              {/* 9. 返回 Base64 图片数据 */}
-              {activeProviderIsOpenAICompatible && (
-                <div className="block">
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <span className="block text-sm text-gray-600 dark:text-gray-300">返回 Base64 图片数据</span>
                     <button
                       type="button"
-                      onClick={() => updateActiveProfile({ responseFormatB64Json: !activeProfile.responseFormatB64Json }, true)}
-                      className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${activeProfile.responseFormatB64Json ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
-                      role="switch"
-                      aria-checked={!!activeProfile.responseFormatB64Json}
-                      aria-label="返回 Base64 图片数据"
+                      onClick={() => setShowApiKey((v) => !v)}
+                      className="absolute right-2 top-1/2 -translate-y-1/2 p-1 text-gray-400 hover:text-gray-600 transition-colors"
+                      tabIndex={-1}
                     >
-                      <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${activeProfile.responseFormatB64Json ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                      {showApiKey ? (
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
+                          <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z" />
+                          <circle cx="12" cy="12" r="3" />
+                        </svg>
+                      ) : (
+                        <svg className="w-4 h-4" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" viewBox="0 0 24 24">
+                          <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94" />
+                          <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19" />
+                          <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24" />
+                          <line x1="1" y1="1" x2="23" y2="23" />
+                        </svg>
+                      )}
                     </button>
                   </div>
-                  <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                    开启后在请求体中追加 <code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">response_format: b64_json</code>，使接口直接返回 Base64 编码的图片数据而非 URL。并非所有服务商和网关都支持此功能。
+                  <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
+                    支持通过查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">?apiKey=</code>
                   </div>
                 </div>
-              )}
-
-              {/* 10. Codex CLI 兼容模式 */}
-              {activeProfile.provider === 'openai' && (
                 <div className="block">
-                  <div className="mb-1.5 flex items-center justify-between">
-                    <span className="block text-sm text-gray-600 dark:text-gray-300">Codex CLI 兼容模式</span>
-                    <button
-                      type="button"
-                      onClick={() => updateActiveProfile({ codexCli: !activeProfile.codexCli }, true)}
-                      className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${activeProfile.codexCli ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
-                      role="switch"
-                      aria-checked={activeProfile.codexCli}
-                      aria-label="Codex CLI 兼容模式"
-                    >
-                      <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${activeProfile.codexCli ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
-                    </button>
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API 接口</span>
+                  <div className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200">
+                    Responses API (/v1/responses)
                   </div>
-                  <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
-                    开启后应用 Codex CLI 实际支持的参数。支持查询参数覆盖：<code className="bg-gray-100 dark:bg-white/[0.06] px-1 py-0.5 rounded">codexCli=true</code>。
+                  <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
+                    Agent 对话固定使用 Responses API，但不要求模型本身支持原生图像生成工具。
                   </div>
                 </div>
-              )}
-
-              {/* 11. 请求超时 */}
-              {activeProviderIsOpenAICompatible && (
                 <label className="block">
-                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求超时 (秒)</span>
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">模型 ID</span>
                   <input
-                    value={timeoutInput}
-                    onChange={(e) => setTimeoutInput(e.target.value)}
-                    onBlur={commitTimeout}
-                    type="number"
-                    min={10}
-                    max={600}
+                    value={activeProfile.model}
+                    onChange={(e) => updateActiveProfile({ model: e.target.value })}
+                    onBlur={(e) => commitActiveProfilePatch({ model: e.target.value })}
+                    type="text"
+                    placeholder={DEFAULT_RESPONSES_MODEL}
                     className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                   />
+                  <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
+                    {activeCustomProvider ? <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{activeCustomProvider.name}</code>。</> : <>文本或多模态 Responses 模型均可；只有选择“使用 Agent 图像生成工具”时才需要模型支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code>。</>}
+                    {activeProfile.provider === 'openai' && <>支持通过查询参数覆盖：<code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">?model=</code>。</>}
+                  </div>
                 </label>
-              )}
+                <label className="block">
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">最大工具调用轮数</span>
+                  <input
+                    value={agentMaxToolRoundsInput}
+                    onChange={(e) => setAgentMaxToolRoundsInput(e.target.value)}
+                    onBlur={commitAgentMaxToolRounds}
+                    type="number"
+                    min={1}
+                    max={50}
+                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                  />
+                  <div data-selectable-text className="mt-1.5 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
+                    默认 15。用于限制 Agent 连续调用工具时的最大轮数，防止无限循环。
+                  </div>
+                </label>
+                <div className="block">
+                  <div className="mb-1 flex items-center justify-between gap-3">
+                    <span className="block text-sm text-gray-600 dark:text-gray-300">网络搜索</span>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const agentMaxToolRounds = agentMaxToolRoundsInput.trim() === ''
+                          ? DEFAULT_AGENT_MAX_TOOL_ROUNDS
+                          : normalizeAgentMaxToolRounds(agentMaxToolRoundsInput, draft.agentMaxToolRounds)
+                        setAgentMaxToolRoundsInput(String(agentMaxToolRounds))
+                        commitSettings({ ...draft, agentMaxToolRounds, agentWebSearch: !draft.agentWebSearch })
+                      }}
+                      className={`relative inline-flex h-4 w-7 shrink-0 items-center rounded-full transition-colors ${draft.agentWebSearch ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+                      role="switch"
+                      aria-checked={draft.agentWebSearch}
+                      aria-label="网络搜索"
+                    >
+                      <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${draft.agentWebSearch ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                    </button>
+                  </div>
+                  <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
+                    启用 Responses API 的 <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-[10px] dark:bg-white/[0.06]">web_search</code> 工具。模型每次调用此工具会产生少量固定价格的额外计费。
+                  </div>
+                </div>
+              </div>
+
+              <div className="space-y-4 rounded-2xl border border-gray-200/70 bg-gray-50/70 p-4 dark:border-white/[0.08] dark:bg-white/[0.03]">
+                <div>
+                  <div className="text-sm font-medium text-gray-700 dark:text-gray-200">图片生成配置</div>
+                  <div data-selectable-text className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
+                    控制 Agent 需要生成图片时使用的后端。独立 Images API 会通过客户端函数工具调用下方配置。
+                  </div>
+                </div>
+                <div className="block">
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">图片生成方式</span>
+                  <Select
+                    value={draft.agentImageGenerationBackend}
+                    onChange={(value) => commitSettings({ ...draft, agentImageGenerationBackend: value === 'image-api' ? 'image-api' : 'native' })}
+                    options={[
+                      { label: '使用 Agent 图像生成工具', value: 'native' },
+                      { label: '独立 Images API', value: 'image-api' },
+                    ]}
+                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                  />
+                  <div data-selectable-text className="mt-1.5 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
+                    使用 Agent 图像生成工具时沿用上方 Responses 配置，并要求模型支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code>；独立 Images API 不要求对话模型具备生图能力。
+                  </div>
+                </div>
+                {draft.agentImageGenerationBackend === 'native' && activeProfile.provider === 'openai' && (
+                  <div className="block space-y-3">
+                    <div>
+                      <div className="mb-1.5 flex items-center justify-between gap-3">
+                        <span className="block text-sm text-gray-600 dark:text-gray-300">流式传输</span>
+                        <button
+                          type="button"
+                          onClick={() => updateActiveProfile({ streamImages: !activeProfile.streamImages }, true)}
+                          className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${activeProfile.streamImages ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+                          role="switch"
+                          aria-checked={!!activeProfile.streamImages}
+                          aria-label="流式传输"
+                        >
+                          <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${activeProfile.streamImages ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                        </button>
+                      </div>
+                      <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
+                        原生 image_generation 工具支持流式返回中间图像，并非所有兼容服务商都支持。
+                      </div>
+                    </div>
+                    <label className={`block ${activeProfile.streamImages ? '' : 'opacity-60'}`}>
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求中间步骤图像数</span>
+                      <Select
+                        value={normalizeStreamPartialImages(activeProfile.streamPartialImages)}
+                        onChange={(value) => updateActiveProfile({ streamPartialImages: normalizeStreamPartialImages(value) }, true)}
+                        disabled={!activeProfile.streamImages}
+                        options={[
+                          { label: '0，不请求', value: 0 },
+                          { label: '1 张', value: 1 },
+                          { label: '2 张', value: 2 },
+                          { label: '3 张', value: 3 },
+                        ]}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                    </label>
+                  </div>
+                )}
+                {draft.agentImageGenerationBackend === 'image-api' && (
+                  <div className="space-y-4 rounded-2xl border border-gray-200/70 bg-white/60 p-4 dark:border-white/[0.08] dark:bg-white/[0.03]">
+                    <div className="block">
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
+                      <Select
+                        value={agentImageProfile.provider}
+                        onChange={handleAgentImageProviderChange}
+                        options={agentImageProviderOptions}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                    </div>
+                    {agentImageProviderUsesApiUrl && (
+                      <label className="block">
+                        <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API URL</span>
+                        <input
+                          value={agentImageProfile.baseUrl}
+                          onChange={(e) => updateAgentImageProfile({ baseUrl: e.target.value })}
+                          onBlur={(e) => updateAgentImageProfile({ baseUrl: e.target.value }, true)}
+                          type="text"
+                          disabled={agentImageApiProxyEnabled}
+                          placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
+                          className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${agentImageApiProxyEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                        />
+                        {agentImageApiProxyEnabled && (
+                          <div data-selectable-text className="mt-1.5 text-xs text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</div>
+                        )}
+                      </label>
+                    )}
+                    {apiProxyAvailable && agentImageProviderIsOpenAICompatible && !agentImageCustomProviderAsync && (
+                      <div className="block">
+                        <div className="mb-1.5 flex items-center justify-between">
+                          <span className="block text-sm text-gray-600 dark:text-gray-300">API 代理</span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (!apiProxyLocked) updateAgentImageProfile({ apiProxy: !agentImageProfile.apiProxy }, true)
+                            }}
+                            disabled={apiProxyLocked}
+                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageApiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
+                            role="switch"
+                            aria-checked={agentImageApiProxyChecked}
+                            aria-label="Agent 图像生成 API 代理"
+                          >
+                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageApiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                          </button>
+                        </div>
+                        <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
+                          {apiProxyLocked ? '部署端已锁定代理开启，请求经服务器转发到上游 API。' : '开启后图片生成请求经服务器转发到上游 API，可绕过浏览器跨域限制。'}
+                        </div>
+                      </div>
+                    )}
+                    <label className="block">
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API Key</span>
+                      <input
+                        value={agentImageProfile.apiKey}
+                        onChange={(e) => updateAgentImageProfile({ apiKey: e.target.value })}
+                        onBlur={(e) => updateAgentImageProfile({ apiKey: e.target.value }, true)}
+                        type={showApiKey ? 'text' : 'password'}
+                        placeholder={agentImageProfile.provider === 'fal' ? 'FAL_KEY' : 'sk-...'}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">模型 ID</span>
+                      <input
+                        value={agentImageProfile.model}
+                        onChange={(e) => updateAgentImageProfile({ model: e.target.value })}
+                        onBlur={(e) => updateAgentImageProfile({ model: e.target.value }, true)}
+                        type="text"
+                        placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_MODEL : DEFAULT_IMAGES_MODEL}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                      <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
+                        {agentImageCustomProvider ? <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{agentImageCustomProvider.name}</code>。</> : <>Images API 通常使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_IMAGES_MODEL}</code>。</>}
+                      </div>
+                    </label>
+                    {agentImageProviderIsOpenAICompatible && (
+                      <div className="block">
+                        <div className="mb-1.5 flex items-center justify-between">
+                          <span className="block text-sm text-gray-600 dark:text-gray-300">返回 Base64 图片数据</span>
+                          <button
+                            type="button"
+                            onClick={() => updateAgentImageProfile({ responseFormatB64Json: !agentImageProfile.responseFormatB64Json }, true)}
+                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageProfile.responseFormatB64Json ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+                            role="switch"
+                            aria-checked={!!agentImageProfile.responseFormatB64Json}
+                            aria-label="Agent 图像生成返回 Base64 图片数据"
+                          >
+                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageProfile.responseFormatB64Json ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                          </button>
+                        </div>
+                        <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
+                          开启后在图片生成请求体中追加 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">response_format: b64_json</code>。
+                        </div>
+                      </div>
+                    )}
+                    {agentImageProviderIsOpenAICompatible && (
+                      <label className="block">
+                        <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求超时 (秒)</span>
+                        <input
+                          value={agentImageProfile.timeout}
+                          onChange={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || agentImageProfile.timeout })}
+                          onBlur={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || DEFAULT_SETTINGS.timeout }, true)}
+                          type="number"
+                          min={10}
+                          max={600}
+                          className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                        />
+                      </label>
+                    )}
+                  </div>
+                )}
+              </div>
             </div>
             )}
             

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -361,7 +361,7 @@ export default function SettingsModal() {
   const activeProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, activeProfile.provider)
   const activeProviderUsesApiUrl = activeProviderIsOpenAICompatible || activeProfile.provider === 'fal'
   const activeCustomProvider = draft.customProviders.find((provider) => provider.id === activeProfile.provider)
-  const imageProfile = draft.imageApiProfile
+  const imageProfile: ApiProfile = activeProfile.imageApiProfile!
   const imageProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, imageProfile.provider)
   const imageProviderUsesApiUrl = imageProviderIsOpenAICompatible || imageProfile.provider === 'fal'
   const imageCustomProvider = draft.customProviders.find((provider) => provider.id === imageProfile.provider)
@@ -588,11 +588,11 @@ export default function SettingsModal() {
 
     // 构建图像配置的 settings JSON
     const imageSettings: Record<string, unknown> = {}
-    if (draft.agentImageGenerationBackend === 'image-api') {
+    if (activeProfile.agentImageGenerationBackend === 'image-api') {
       imageSettings.agentImageGenerationBackend = 'image-api'
       const imageExport: ApiProfile = {
-        ...draft.imageApiProfile,
-        apiKey: options.includeApiKey ? draft.imageApiProfile.apiKey : '',
+        ...imageProfile,
+        apiKey: options.includeApiKey ? (imageProfile.apiKey) : '',
       }
       if (!options.includeApiKey) {
         if (options.useNewApiAddress) imageExport.baseUrl = '{address}'
@@ -691,17 +691,14 @@ export default function SettingsModal() {
   }
 
   const updateImageProfile = (patch: Partial<ApiProfile>, commit = false) => {
-    const nextDraft = {
-      ...draft,
+    updateActiveProfile({
       imageApiProfile: {
-        ...draft.imageApiProfile,
+        ...imageProfile,
         ...patch,
         apiMode: 'images' as const,
         streamImages: false,
       },
-    }
-    setDraft(nextDraft)
-    if (commit) commitSettings(nextDraft)
+    }, commit)
   }
 
   const handleImageProviderChange = (provider: string | number) => {
@@ -715,15 +712,11 @@ export default function SettingsModal() {
 
     const providerId = String(provider)
     const customProvider = draft.customProviders.find((item) => item.id === providerId)
-    const nextProfile = switchApiProfileProvider(draft.imageApiProfile, providerId, customProvider)
-    commitSettings({
-      ...draft,
-      imageApiProfile: {
-        ...nextProfile,
-        apiMode: 'images',
-        streamImages: false,
-      },
-    })
+    const nextProfile = switchApiProfileProvider(imageProfile, providerId, customProvider)
+    updateActiveProfile({
+      imageApiProfile: { ...nextProfile, apiMode: 'images' as const, streamImages: false } as ApiProfile,
+      agentImageGenerationBackend: 'image-api' as const,
+    }, true)
   }
 
   const handleChatProviderChange = (provider: string | number) => {
@@ -1110,13 +1103,14 @@ export default function SettingsModal() {
     const providerId = provider.id
     const nextDraft = normalizeSettings({
       ...draft,
-      customProviders: draft.customProviders.filter((provider) => provider.id !== providerId),
-      profiles: draft.profiles.map((profile) =>
-        profile.provider === providerId ? switchApiProfileProvider(profile, 'openai') : profile,
-      ),
-      imageApiProfile: draft.imageApiProfile.provider === providerId
-        ? switchApiProfileProvider(draft.imageApiProfile, 'openai')
-        : draft.imageApiProfile,
+      customProviders: draft.customProviders.filter((p) => p.id !== providerId),
+      profiles: draft.profiles.map((p) => {
+        if (p.provider === providerId) return switchApiProfileProvider(p, 'openai')
+        if (p.id === activeProfile.id && p.imageApiProfile?.provider === providerId) {
+          return { ...p, imageApiProfile: switchApiProfileProvider(p.imageApiProfile!, 'openai') }
+        }
+        return p
+      }),
     })
     commitSettings(nextDraft)
     showToast('服务商已删除', 'success')
@@ -1839,8 +1833,8 @@ export default function SettingsModal() {
                 <div className="block">
                   <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">图片生成方式</span>
                   <Select
-                    value={draft.agentImageGenerationBackend}
-                    onChange={(value) => commitSettings({ ...draft, agentImageGenerationBackend: value === 'image-api' ? 'image-api' : 'native' })}
+                    value={activeProfile.agentImageGenerationBackend}
+                    onChange={(value) => updateActiveProfile({ agentImageGenerationBackend: value === 'image-api' ? 'image-api' as const : 'native' as const }, true)}
                     options={[
                       { label: '使用 Agent 图像生成工具', value: 'native' },
                       { label: '独立 Images API', value: 'image-api' },
@@ -1851,7 +1845,7 @@ export default function SettingsModal() {
                     使用 Agent 图像生成工具时沿用上方 Responses 配置，并要求模型支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code>；独立 Images API 不要求对话模型具备生图能力。
                   </div>
                 </div>
-                {draft.agentImageGenerationBackend === 'native' && activeProfile.provider === 'openai' && (
+                {activeProfile.agentImageGenerationBackend === 'native' && activeProfile.provider === 'openai' && (
                   <div className="block space-y-3">
                     <div>
                       <div className="mb-1.5 flex items-center justify-between gap-3">
@@ -1888,7 +1882,7 @@ export default function SettingsModal() {
                     </label>
                   </div>
                 )}
-                {draft.agentImageGenerationBackend === 'image-api' && (
+                {activeProfile.agentImageGenerationBackend === 'image-api' && (
                   <div className="space-y-4 rounded-2xl border border-gray-200/70 bg-white/60 p-4 dark:border-white/[0.08] dark:bg-white/[0.03]">
                     <div className="block">
                       <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -361,10 +361,18 @@ export default function SettingsModal() {
   const activeProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, activeProfile.provider)
   const activeProviderUsesApiUrl = activeProviderIsOpenAICompatible || activeProfile.provider === 'fal'
   const activeCustomProvider = draft.customProviders.find((provider) => provider.id === activeProfile.provider)
+  const agentImageProfile = draft.agentImageApiProfile
+  const agentImageProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, agentImageProfile.provider)
+  const agentImageProviderUsesApiUrl = agentImageProviderIsOpenAICompatible || agentImageProfile.provider === 'fal'
+  const agentImageCustomProvider = draft.customProviders.find((provider) => provider.id === agentImageProfile.provider)
   const activeProfileApiProxyEligible = isProfileApiProxyEligible(draft, activeProfile)
   const activeCustomProviderAsync = isAsyncCustomProvider(activeCustomProvider)
+  const agentImageProfileApiProxyEligible = isProfileApiProxyEligible(draft, agentImageProfile)
+  const agentImageCustomProviderAsync = isAsyncCustomProvider(agentImageCustomProvider)
   const apiProxyChecked = activeProfileApiProxyEligible && (apiProxyLocked || activeProfile.apiProxy)
   const apiProxyEnabled = apiProxyAvailable && activeProfileApiProxyEligible && apiProxyChecked
+  const agentImageApiProxyChecked = agentImageProfileApiProxyEligible && (apiProxyLocked || agentImageProfile.apiProxy)
+  const agentImageApiProxyEnabled = apiProxyAvailable && agentImageProfileApiProxyEligible && agentImageApiProxyChecked
   const defaultProviderOrder = ['openai', 'fal', ...draft.customProviders.map(p => p.id)]
   const providerOrder = draft.providerOrder || defaultProviderOrder
 
@@ -396,6 +404,16 @@ export default function SettingsModal() {
       return validA - validB
     })
   ]
+
+  const agentImageProviderOptions = unorderedProviderOptions
+    .map(({ label, value }) => ({ label, value }))
+    .sort((a, b) => {
+      const aIndex = providerOrder.indexOf(String(a.value))
+      const bIndex = providerOrder.indexOf(String(b.value))
+      const validA = aIndex !== -1 ? aIndex : defaultProviderOrder.indexOf(String(a.value))
+      const validB = bIndex !== -1 ? bIndex : defaultProviderOrder.indexOf(String(b.value))
+      return validA - validB
+    })
 
   const getDefaultModelForMode = (apiMode: AppSettings['apiMode']) =>
     apiMode === 'responses' ? DEFAULT_RESPONSES_MODEL : DEFAULT_IMAGES_MODEL
@@ -652,6 +670,34 @@ export default function SettingsModal() {
   const commitActiveProfilePatch = (patch: Partial<ApiProfile>) => {
     const nextDraft = getDraftWithActiveProfilePatch(patch)
     commitSettings(nextDraft)
+  }
+
+  const updateAgentImageProfile = (patch: Partial<ApiProfile>, commit = false) => {
+    const nextDraft = {
+      ...draft,
+      agentImageApiProfile: {
+        ...draft.agentImageApiProfile,
+        ...patch,
+        apiMode: 'images' as const,
+        streamImages: false,
+      },
+    }
+    setDraft(nextDraft)
+    if (commit) commitSettings(nextDraft)
+  }
+
+  const handleAgentImageProviderChange = (provider: string | number) => {
+    const providerId = String(provider)
+    const customProvider = draft.customProviders.find((item) => item.id === providerId)
+    const nextProfile = switchApiProfileProvider(draft.agentImageApiProfile, providerId, customProvider)
+    commitSettings({
+      ...draft,
+      agentImageApiProfile: {
+        ...nextProfile,
+        apiMode: 'images',
+        streamImages: false,
+      },
+    })
   }
 
   const handleClose = () => {
@@ -1419,6 +1465,139 @@ export default function SettingsModal() {
 
             {activeTab === 'agent' && (
               <div className="space-y-4">
+                <div className="block">
+                  <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">图像生成方式</span>
+                  <Select
+                    value={draft.agentImageGenerationBackend}
+                    onChange={(value) => commitSettings({ ...draft, agentImageGenerationBackend: value === 'image-api' ? 'image-api' : 'native' })}
+                    options={[
+                      { label: 'Responses 原生 image_generation', value: 'native' },
+                      { label: '独立 Image API 配置', value: 'image-api' },
+                    ]}
+                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                  />
+                  <div data-selectable-text className="mt-1.5 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
+                    原生模式要求当前 Responses 模型支持 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">image_generation</code> 工具；独立 Image API 模式会让 Agent 调用客户端函数工具，再由下方图像配置生成图片。
+                  </div>
+                </div>
+                {draft.agentImageGenerationBackend === 'image-api' && (
+                  <div className="space-y-4 rounded-2xl border border-gray-200/70 bg-gray-50/70 p-4 dark:border-white/[0.08] dark:bg-white/[0.03]">
+                    <div>
+                      <div className="text-sm font-medium text-gray-700 dark:text-gray-200">Agent 图像生成配置</div>
+                      <div data-selectable-text className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
+                        这套配置只用于 Agent 工具生成图片；对话仍使用 API 配置页里当前的 Responses 配置。
+                      </div>
+                    </div>
+                    <div className="block">
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
+                      <Select
+                        value={agentImageProfile.provider}
+                        onChange={handleAgentImageProviderChange}
+                        options={agentImageProviderOptions}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                    </div>
+                    {agentImageProviderUsesApiUrl && (
+                      <label className="block">
+                        <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API URL</span>
+                        <input
+                          value={agentImageProfile.baseUrl}
+                          onChange={(e) => updateAgentImageProfile({ baseUrl: e.target.value })}
+                          onBlur={(e) => updateAgentImageProfile({ baseUrl: e.target.value }, true)}
+                          type="text"
+                          disabled={agentImageApiProxyEnabled}
+                          placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
+                          className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${agentImageApiProxyEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                        />
+                        {agentImageApiProxyEnabled && (
+                          <div data-selectable-text className="mt-1.5 text-xs text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</div>
+                        )}
+                      </label>
+                    )}
+                    {apiProxyAvailable && agentImageProviderIsOpenAICompatible && !agentImageCustomProviderAsync && (
+                      <div className="block">
+                        <div className="mb-1.5 flex items-center justify-between">
+                          <span className="block text-sm text-gray-600 dark:text-gray-300">API 代理</span>
+                          <button
+                            type="button"
+                            onClick={() => {
+                              if (!apiProxyLocked) updateAgentImageProfile({ apiProxy: !agentImageProfile.apiProxy }, true)
+                            }}
+                            disabled={apiProxyLocked}
+                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageApiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
+                            role="switch"
+                            aria-checked={agentImageApiProxyChecked}
+                            aria-label="Agent 图像生成 API 代理"
+                          >
+                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageApiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                          </button>
+                        </div>
+                        <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
+                          {apiProxyLocked ? '部署端已锁定代理开启，请求经服务器转发到上游 API。' : '开启后图片生成请求经服务器转发到上游 API，可绕过浏览器跨域限制。'}
+                        </div>
+                      </div>
+                    )}
+                    <label className="block">
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API Key</span>
+                      <input
+                        value={agentImageProfile.apiKey}
+                        onChange={(e) => updateAgentImageProfile({ apiKey: e.target.value })}
+                        onBlur={(e) => updateAgentImageProfile({ apiKey: e.target.value }, true)}
+                        type={showApiKey ? 'text' : 'password'}
+                        placeholder={agentImageProfile.provider === 'fal' ? 'FAL_KEY' : 'sk-...'}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">模型 ID</span>
+                      <input
+                        value={agentImageProfile.model}
+                        onChange={(e) => updateAgentImageProfile({ model: e.target.value })}
+                        onBlur={(e) => updateAgentImageProfile({ model: e.target.value }, true)}
+                        type="text"
+                        placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_MODEL : DEFAULT_IMAGES_MODEL}
+                        className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                      />
+                      <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
+                        {agentImageCustomProvider ? <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{agentImageCustomProvider.name}</code>。</> : <>Images API 通常使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_IMAGES_MODEL}</code>。</>}
+                      </div>
+                    </label>
+                    {agentImageProviderIsOpenAICompatible && (
+                      <div className="block">
+                        <div className="mb-1.5 flex items-center justify-between">
+                          <span className="block text-sm text-gray-600 dark:text-gray-300">返回 Base64 图片数据</span>
+                          <button
+                            type="button"
+                            onClick={() => updateAgentImageProfile({ responseFormatB64Json: !agentImageProfile.responseFormatB64Json }, true)}
+                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageProfile.responseFormatB64Json ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+                            role="switch"
+                            aria-checked={!!agentImageProfile.responseFormatB64Json}
+                            aria-label="Agent 图像生成返回 Base64 图片数据"
+                          >
+                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageProfile.responseFormatB64Json ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                          </button>
+                        </div>
+                        <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
+                          开启后在图片生成请求体中追加 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">response_format: b64_json</code>。
+                        </div>
+                      </div>
+                    )}
+                    {agentImageProviderIsOpenAICompatible && (
+                      <label className="block">
+                        <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求超时 (秒)</span>
+                        <input
+                          value={agentImageProfile.timeout}
+                          onChange={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || agentImageProfile.timeout })}
+                          onBlur={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || DEFAULT_SETTINGS.timeout }, true)}
+                          type="number"
+                          min={10}
+                          max={600}
+                          className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                        />
+                      </label>
+                    )}
+                  </div>
+                )}
                 <label className="block">
                   <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">最大工具调用轮数</span>
                   <input

--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -205,18 +205,6 @@ function isProfileApiProxyEligible(settings: AppSettings, profile: ApiProfile) {
   return !isAsyncCustomProvider(customProvider)
 }
 
-function toAgentResponsesProfile(profile: ApiProfile): ApiProfile {
-  const switched = switchApiProfileProvider(profile, 'openai')
-  return {
-    ...switched,
-    id: profile.id,
-    name: profile.name,
-    apiKey: profile.apiKey,
-    apiMode: 'responses',
-    model: profile.provider === 'openai' && profile.apiMode === 'responses' ? profile.model : DEFAULT_RESPONSES_MODEL,
-  }
-}
-
 const CUSTOM_PROVIDER_LLM_PROMPT = `# 角色
 你是 API 文档解析助手。你的任务是根据用户提供的图像生成 API 文档，生成本应用可导入的自定义服务商配置 JSON。
 
@@ -373,18 +361,18 @@ export default function SettingsModal() {
   const activeProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, activeProfile.provider)
   const activeProviderUsesApiUrl = activeProviderIsOpenAICompatible || activeProfile.provider === 'fal'
   const activeCustomProvider = draft.customProviders.find((provider) => provider.id === activeProfile.provider)
-  const agentImageProfile = draft.agentImageApiProfile
-  const agentImageProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, agentImageProfile.provider)
-  const agentImageProviderUsesApiUrl = agentImageProviderIsOpenAICompatible || agentImageProfile.provider === 'fal'
-  const agentImageCustomProvider = draft.customProviders.find((provider) => provider.id === agentImageProfile.provider)
+  const imageProfile = draft.imageApiProfile
+  const imageProviderIsOpenAICompatible = isOpenAICompatibleProvider(draft, imageProfile.provider)
+  const imageProviderUsesApiUrl = imageProviderIsOpenAICompatible || imageProfile.provider === 'fal'
+  const imageCustomProvider = draft.customProviders.find((provider) => provider.id === imageProfile.provider)
   const activeProfileApiProxyEligible = isProfileApiProxyEligible(draft, activeProfile)
   const activeCustomProviderAsync = isAsyncCustomProvider(activeCustomProvider)
-  const agentImageProfileApiProxyEligible = isProfileApiProxyEligible(draft, agentImageProfile)
-  const agentImageCustomProviderAsync = isAsyncCustomProvider(agentImageCustomProvider)
+  const imageProfileApiProxyEligible = isProfileApiProxyEligible(draft, imageProfile)
+  const imageCustomProviderAsync = isAsyncCustomProvider(imageCustomProvider)
   const apiProxyChecked = activeProfileApiProxyEligible && (apiProxyLocked || activeProfile.apiProxy)
   const apiProxyEnabled = apiProxyAvailable && activeProfileApiProxyEligible && apiProxyChecked
-  const agentImageApiProxyChecked = agentImageProfileApiProxyEligible && (apiProxyLocked || agentImageProfile.apiProxy)
-  const agentImageApiProxyEnabled = apiProxyAvailable && agentImageProfileApiProxyEligible && agentImageApiProxyChecked
+  const imageApiProxyChecked = imageProfileApiProxyEligible && (apiProxyLocked || imageProfile.apiProxy)
+  const imageApiProxyEnabled = apiProxyAvailable && imageProfileApiProxyEligible && imageApiProxyChecked
   const defaultProviderOrder = ['openai', 'fal', ...draft.customProviders.map(p => p.id)]
   const providerOrder = draft.providerOrder || defaultProviderOrder
 
@@ -406,7 +394,7 @@ export default function SettingsModal() {
     })),
   ]
 
-  const agentImageProviderOptions = [
+  const imageProviderOptions = [
     { label: '创建自定义服务商', value: ADD_CUSTOM_PROVIDER_VALUE, variant: 'action' as const },
     ...unorderedProviderOptions,
   ]
@@ -419,6 +407,8 @@ export default function SettingsModal() {
       const validB = bIndex !== -1 ? bIndex : defaultProviderOrder.indexOf(String(b.value))
       return validA - validB
     })
+
+  const chatProviderOptions = imageProviderOptions.filter((opt) => opt.value !== 'fal')
 
   const getDefaultModelForMode = (apiMode: AppSettings['apiMode']) =>
     apiMode === 'responses' ? DEFAULT_RESPONSES_MODEL : DEFAULT_IMAGES_MODEL
@@ -449,7 +439,6 @@ export default function SettingsModal() {
       ...displaySettings,
       profiles: displaySettings.profiles.map((profile) => ({
         ...profile,
-        ...(profile.id === displaySettings.activeProfileId ? toAgentResponsesProfile(profile) : profile),
         apiProxy: isProfileApiProxyEligible(displaySettings, profile) && apiProxyAvailable
           ? (apiProxyLocked || profile.apiProxy)
           : false,
@@ -665,7 +654,7 @@ export default function SettingsModal() {
 
   const getDraftWithActiveProfilePatch = (patch: Partial<ApiProfile>) => ({
       ...draft,
-      profiles: draft.profiles.map((profile) => profile.id === activeProfile.id ? { ...profile, ...patch, apiMode: 'responses' as const } : profile),
+      profiles: draft.profiles.map((profile) => profile.id === activeProfile.id ? { ...profile, ...patch } : profile),
     })
 
   const updateActiveProfile = (patch: Partial<ApiProfile>, commit = false) => {
@@ -679,11 +668,11 @@ export default function SettingsModal() {
     commitSettings(nextDraft)
   }
 
-  const updateAgentImageProfile = (patch: Partial<ApiProfile>, commit = false) => {
+  const updateImageProfile = (patch: Partial<ApiProfile>, commit = false) => {
     const nextDraft = {
       ...draft,
-      agentImageApiProfile: {
-        ...draft.agentImageApiProfile,
+      imageApiProfile: {
+        ...draft.imageApiProfile,
         ...patch,
         apiMode: 'images' as const,
         streamImages: false,
@@ -693,7 +682,7 @@ export default function SettingsModal() {
     if (commit) commitSettings(nextDraft)
   }
 
-  const handleAgentImageProviderChange = (provider: string | number) => {
+  const handleImageProviderChange = (provider: string | number) => {
     if (provider === ADD_CUSTOM_PROVIDER_VALUE) {
       setEditingCustomProviderId(null)
       setCustomProviderForm(createDefaultCustomProviderForm())
@@ -704,15 +693,31 @@ export default function SettingsModal() {
 
     const providerId = String(provider)
     const customProvider = draft.customProviders.find((item) => item.id === providerId)
-    const nextProfile = switchApiProfileProvider(draft.agentImageApiProfile, providerId, customProvider)
+    const nextProfile = switchApiProfileProvider(draft.imageApiProfile, providerId, customProvider)
     commitSettings({
       ...draft,
-      agentImageApiProfile: {
+      imageApiProfile: {
         ...nextProfile,
         apiMode: 'images',
         streamImages: false,
       },
     })
+  }
+
+  const handleChatProviderChange = (provider: string | number) => {
+    if (defaultConfigOnly) return
+    if (provider === ADD_CUSTOM_PROVIDER_VALUE) {
+      setEditingCustomProviderId(null)
+      setCustomProviderForm(createDefaultCustomProviderForm())
+      setShowCustomProviderImport(true)
+      setCustomProviderImportError(null)
+      return
+    }
+
+    const providerId = String(provider)
+    const customProvider = draft.customProviders.find((item) => item.id === providerId)
+    const nextProfile = switchApiProfileProvider(activeProfile, providerId, customProvider)
+    updateActiveProfile({ ...nextProfile, apiMode: 'responses' as const }, true)
   }
 
   const handleClose = () => {
@@ -821,7 +826,7 @@ export default function SettingsModal() {
   const createNewProfile = () => {
     if (defaultConfigOnly) return
     setReusedTaskApiProfile(null)
-    const profile = toAgentResponsesProfile(createDefaultOpenAIProfile({ id: newId('openai'), name: '新配置', apiMode: 'responses' }))
+    const profile = createDefaultOpenAIProfile({ id: newId('openai'), name: '新配置', apiMode: 'responses' })
     const nextDraft = normalizeSettings({ 
         ...draft, 
         profiles: [...draft.profiles, profile],
@@ -836,10 +841,9 @@ export default function SettingsModal() {
     setReusedTaskApiProfile(null)
     setDuplicateProfileTooltipVisible(false)
     const profile: ApiProfile = {
-      ...toAgentResponsesProfile(activeProfile),
+      ...activeProfile,
       id: newId(activeProfile.provider === 'openai' ? 'openai' : 'profile'),
       name: `${activeProfile.name}（复制）`,
-      apiMode: 'responses',
     }
     const nextDraft = normalizeSettings({
       ...draft,
@@ -855,7 +859,6 @@ export default function SettingsModal() {
     setReusedTaskApiProfile(null)
     const nextDraft = normalizeSettings({
       ...draft,
-      profiles: draft.profiles.map((profile) => profile.id === id ? toAgentResponsesProfile(profile) : profile),
       activeProfileId: id,
     })
     commitSettings(nextDraft)
@@ -1089,9 +1092,9 @@ export default function SettingsModal() {
       profiles: draft.profiles.map((profile) =>
         profile.provider === providerId ? switchApiProfileProvider(profile, 'openai') : profile,
       ),
-      agentImageApiProfile: draft.agentImageApiProfile.provider === providerId
-        ? switchApiProfileProvider(draft.agentImageApiProfile, 'openai')
-        : draft.agentImageApiProfile,
+      imageApiProfile: draft.imageApiProfile.provider === providerId
+        ? switchApiProfileProvider(draft.imageApiProfile, 'openai')
+        : draft.imageApiProfile,
     })
     commitSettings(nextDraft)
     showToast('服务商已删除', 'success')
@@ -1126,12 +1129,11 @@ export default function SettingsModal() {
               ...mergedDraft,
               profiles: mergedDraft.profiles
                 .filter((profile) => profile.id === activeProfile.id || profile.id !== importedProfile.id)
-                .map((profile) => profile.id === activeProfile.id ? toAgentResponsesProfile({ ...importedProfile, id: activeProfile.id }) : profile),
+                .map((profile) => profile.id === activeProfile.id ? { ...importedProfile, id: activeProfile.id } : profile),
               activeProfileId: activeProfile.id,
             })
           : normalizeSettings({
               ...mergedDraft,
-              profiles: mergedDraft.profiles.map((profile) => profile.id === importedProfile.id ? toAgentResponsesProfile(profile) : profile),
               activeProfileId: importedProfile.id,
             })
         setDraft(nextDraft)
@@ -1642,16 +1644,20 @@ export default function SettingsModal() {
                 <div>
                   <div className="text-sm font-medium text-gray-700 dark:text-gray-200">Agent 配置</div>
                   <div data-selectable-text className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
-                    当前配置用于 Agent 对话请求。这里固定使用 Responses API；是否具备原生图像生成能力由下方图片生成方式决定。
+                    Agent 对话使用的 Responses API 配置。可通过上方下拉菜单管理多套对话配置；是否具备原生图像生成能力由下方图片生成方式决定。
                   </div>
                 </div>
                 <div className="block">
                   <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
-                  <div className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200">
-                    OpenAI 兼容接口
-                  </div>
+                  <Select
+                    value={activeProfile.provider}
+                    onChange={handleChatProviderChange}
+                    options={chatProviderOptions}
+                    disabled={defaultConfigOnly}
+                    className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
+                  />
                   <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                    Agent 对话固定使用 OpenAI-compatible Responses API；其他图片服务商请在下方“独立 Images API”中配置。
+                    Agent 对话固定使用 OpenAI-compatible Responses API；其他图片服务商请在下方图片生成配置中选择。
                   </div>
                 </div>
                 {activeProviderUsesApiUrl && (
@@ -1805,7 +1811,7 @@ export default function SettingsModal() {
                 <div>
                   <div className="text-sm font-medium text-gray-700 dark:text-gray-200">图片生成配置</div>
                   <div data-selectable-text className="mt-1 text-xs leading-relaxed text-gray-500 dark:text-gray-500">
-                    控制 Agent 需要生成图片时使用的后端。独立 Images API 会通过客户端函数工具调用下方配置。
+                    画廊模式和 Agent 模式使用的图像生成后端。独立 Images API 可通过客户端函数工具调用下方配置。
                   </div>
                 </div>
                 <div className="block">
@@ -1865,45 +1871,45 @@ export default function SettingsModal() {
                     <div className="block">
                       <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">服务商类型</span>
                       <Select
-                        value={agentImageProfile.provider}
-                        onChange={handleAgentImageProviderChange}
-                        options={agentImageProviderOptions}
+                        value={imageProfile.provider}
+                        onChange={handleImageProviderChange}
+                        options={imageProviderOptions}
                         className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                       />
                     </div>
-                    {agentImageProviderUsesApiUrl && (
+                    {imageProviderUsesApiUrl && (
                       <label className="block">
                         <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API URL</span>
                         <input
-                          value={agentImageProfile.baseUrl}
-                          onChange={(e) => updateAgentImageProfile({ baseUrl: e.target.value })}
-                          onBlur={(e) => updateAgentImageProfile({ baseUrl: e.target.value }, true)}
+                          value={imageProfile.baseUrl}
+                          onChange={(e) => updateImageProfile({ baseUrl: e.target.value })}
+                          onBlur={(e) => updateImageProfile({ baseUrl: e.target.value }, true)}
                           type="text"
-                          disabled={agentImageApiProxyEnabled}
-                          placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
-                          className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${agentImageApiProxyEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
+                          disabled={imageApiProxyEnabled}
+                          placeholder={imageProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
+                          className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${imageApiProxyEnabled ? 'cursor-not-allowed opacity-50' : ''}`}
                         />
-                        {agentImageApiProxyEnabled && (
+                        {imageApiProxyEnabled && (
                           <div data-selectable-text className="mt-1.5 text-xs text-yellow-600 dark:text-yellow-500">已开启代理，实际请求目标由部署端决定，此处设置被忽略。</div>
                         )}
                       </label>
                     )}
-                    {apiProxyAvailable && agentImageProviderIsOpenAICompatible && !agentImageCustomProviderAsync && (
+                    {apiProxyAvailable && imageProviderIsOpenAICompatible && !imageCustomProviderAsync && (
                       <div className="block">
                         <div className="mb-1.5 flex items-center justify-between">
                           <span className="block text-sm text-gray-600 dark:text-gray-300">API 代理</span>
                           <button
                             type="button"
                             onClick={() => {
-                              if (!apiProxyLocked) updateAgentImageProfile({ apiProxy: !agentImageProfile.apiProxy }, true)
+                              if (!apiProxyLocked) updateImageProfile({ apiProxy: !imageProfile.apiProxy }, true)
                             }}
                             disabled={apiProxyLocked}
-                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageApiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
+                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${imageApiProxyChecked ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'} ${apiProxyLocked ? 'cursor-not-allowed opacity-70' : ''}`}
                             role="switch"
-                            aria-checked={agentImageApiProxyChecked}
-                            aria-label="Agent 图像生成 API 代理"
+                            aria-checked={imageApiProxyChecked}
+                            aria-label="图像生成 API 代理"
                           >
-                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageApiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${imageApiProxyChecked ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
                           </button>
                         </div>
                         <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
@@ -1914,41 +1920,41 @@ export default function SettingsModal() {
                     <label className="block">
                       <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">API Key</span>
                       <input
-                        value={agentImageProfile.apiKey}
-                        onChange={(e) => updateAgentImageProfile({ apiKey: e.target.value })}
-                        onBlur={(e) => updateAgentImageProfile({ apiKey: e.target.value }, true)}
+                        value={imageProfile.apiKey}
+                        onChange={(e) => updateImageProfile({ apiKey: e.target.value })}
+                        onBlur={(e) => updateImageProfile({ apiKey: e.target.value }, true)}
                         type={showApiKey ? 'text' : 'password'}
-                        placeholder={agentImageProfile.provider === 'fal' ? 'FAL_KEY' : 'sk-...'}
+                        placeholder={imageProfile.provider === 'fal' ? 'FAL_KEY' : 'sk-...'}
                         className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                       />
                     </label>
                     <label className="block">
                       <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">模型 ID</span>
                       <input
-                        value={agentImageProfile.model}
-                        onChange={(e) => updateAgentImageProfile({ model: e.target.value })}
-                        onBlur={(e) => updateAgentImageProfile({ model: e.target.value }, true)}
+                        value={imageProfile.model}
+                        onChange={(e) => updateImageProfile({ model: e.target.value })}
+                        onBlur={(e) => updateImageProfile({ model: e.target.value }, true)}
                         type="text"
-                        placeholder={agentImageProfile.provider === 'fal' ? DEFAULT_FAL_MODEL : DEFAULT_IMAGES_MODEL}
+                        placeholder={imageProfile.provider === 'fal' ? DEFAULT_FAL_MODEL : DEFAULT_IMAGES_MODEL}
                         className="w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50"
                       />
                       <div data-selectable-text className="mt-1.5 text-xs text-gray-500 dark:text-gray-500">
-                        {agentImageCustomProvider ? <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{agentImageCustomProvider.name}</code>。</> : <>Images API 通常使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_IMAGES_MODEL}</code>。</>}
+                        {imageCustomProvider ? <>当前使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{imageCustomProvider.name}</code>。</> : <>Images API 通常使用 <code className="rounded bg-gray-100 px-1 py-0.5 dark:bg-white/[0.06]">{DEFAULT_IMAGES_MODEL}</code>。</>}
                       </div>
                     </label>
-                    {agentImageProviderIsOpenAICompatible && (
+                    {imageProviderIsOpenAICompatible && (
                       <div className="block">
                         <div className="mb-1.5 flex items-center justify-between">
                           <span className="block text-sm text-gray-600 dark:text-gray-300">返回 Base64 图片数据</span>
                           <button
                             type="button"
-                            onClick={() => updateAgentImageProfile({ responseFormatB64Json: !agentImageProfile.responseFormatB64Json }, true)}
-                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${agentImageProfile.responseFormatB64Json ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
+                            onClick={() => updateImageProfile({ responseFormatB64Json: !imageProfile.responseFormatB64Json }, true)}
+                            className={`relative inline-flex h-4 w-7 items-center rounded-full transition-colors ${imageProfile.responseFormatB64Json ? 'bg-blue-500' : 'bg-gray-300 dark:bg-gray-600'}`}
                             role="switch"
-                            aria-checked={!!agentImageProfile.responseFormatB64Json}
-                            aria-label="Agent 图像生成返回 Base64 图片数据"
+                            aria-checked={!!imageProfile.responseFormatB64Json}
+                            aria-label="图像生成返回 Base64 图片数据"
                           >
-                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${agentImageProfile.responseFormatB64Json ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
+                            <span className={`inline-block h-3 w-3 transform rounded-full bg-white shadow transition-transform ${imageProfile.responseFormatB64Json ? 'translate-x-[14px]' : 'translate-x-[2px]'}`} />
                           </button>
                         </div>
                         <div data-selectable-text className="text-xs text-gray-500 dark:text-gray-500">
@@ -1956,13 +1962,13 @@ export default function SettingsModal() {
                         </div>
                       </div>
                     )}
-                    {agentImageProviderIsOpenAICompatible && (
+                    {imageProviderIsOpenAICompatible && (
                       <label className="block">
                         <span className="mb-1.5 block text-sm text-gray-600 dark:text-gray-300">请求超时 (秒)</span>
                         <input
-                          value={agentImageProfile.timeout}
-                          onChange={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || agentImageProfile.timeout })}
-                          onBlur={(e) => updateAgentImageProfile({ timeout: Number(e.target.value) || DEFAULT_SETTINGS.timeout }, true)}
+                          value={imageProfile.timeout}
+                          onChange={(e) => updateImageProfile({ timeout: Number(e.target.value) || imageProfile.timeout })}
+                          onBlur={(e) => updateImageProfile({ timeout: Number(e.target.value) || DEFAULT_SETTINGS.timeout }, true)}
                           type="number"
                           min={10}
                           max={600}

--- a/src/lib/agentApi.test.ts
+++ b/src/lib/agentApi.test.ts
@@ -138,8 +138,8 @@ describe('callAgentResponsesApi', () => {
     })
 
     await callAgentResponsesApi({
-      settings: { ...DEFAULT_SETTINGS, agentImageGenerationBackend: 'image-api' },
-      profile,
+      settings: DEFAULT_SETTINGS,
+      profile: { ...profile, agentImageGenerationBackend: 'image-api' },
       params: DEFAULT_PARAMS,
       input: [{ role: 'user', content: [{ type: 'input_text', text: 'edit' }] }],
       maskDataUrl: 'data:image/png;base64,bWFzaw==',

--- a/src/lib/agentApi.test.ts
+++ b/src/lib/agentApi.test.ts
@@ -122,6 +122,39 @@ describe('callAgentResponsesApi', () => {
     expect(body.tools[0].input_image_mask).toEqual({ image_url: 'data:image/png;base64,bWFzaw==' })
   })
 
+  it('uses client image functions when Agent image backend is Image API', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
+      output: [{
+        type: 'message',
+        content: [{ type: 'output_text', text: 'OK' }],
+      }],
+    }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    }))
+    const profile = createDefaultOpenAIProfile({
+      apiKey: 'test-key',
+      apiMode: 'responses',
+    })
+
+    await callAgentResponsesApi({
+      settings: { ...DEFAULT_SETTINGS, agentImageGenerationBackend: 'image-api' },
+      profile,
+      params: DEFAULT_PARAMS,
+      input: [{ role: 'user', content: [{ type: 'input_text', text: 'edit' }] }],
+      maskDataUrl: 'data:image/png;base64,bWFzaw==',
+    })
+
+    const [, init] = fetchMock.mock.calls[0]
+    const body = JSON.parse(String((init as RequestInit).body))
+    expect(body.tools).toEqual(expect.arrayContaining([
+      expect.objectContaining({ type: 'function', name: 'generate_image' }),
+      expect.objectContaining({ type: 'function', name: 'generate_image_batch' }),
+    ]))
+    expect(body.tools.some((tool: { type?: string }) => tool.type === 'image_generation')).toBe(false)
+    expect(JSON.stringify(body.tools)).not.toContain('input_image_mask')
+  })
+
   it('extracts image_generation results from base64 object fields', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(JSON.stringify({
       output: [{

--- a/src/lib/agentApi.ts
+++ b/src/lib/agentApi.ts
@@ -1,4 +1,4 @@
-import { DEFAULT_AGENT_MAX_TOOL_ROUNDS, DEFAULT_STREAM_PARTIAL_IMAGES, type ApiProfile, type AppSettings, type ResponsesApiResponse, type ResponsesOutputItem, type TaskParams } from '../types'
+import { DEFAULT_AGENT_MAX_TOOL_ROUNDS, DEFAULT_STREAM_PARTIAL_IMAGES, type AgentImageGenerationBackend, type ApiProfile, type AppSettings, type ResponsesApiResponse, type ResponsesOutputItem, type TaskParams } from '../types'
 import { buildApiUrl, readClientDevProxyConfig, shouldUseApiProxy } from './devProxy'
 import { appendStreamingFormatHint, maybeAppendStreamingHint, getApiErrorMessage, MIME_MAP, normalizeBase64Image, pickActualParams } from './imageApiShared'
 
@@ -31,12 +31,12 @@ const AGENT_MATH_FORMATTING_INSTRUCTIONS = [
   '- Do not use LaTeX delimiters like `\\(...\\)` or `\\[...\\]` in visible assistant text.',
 ].join('\n')
 
-function getAgentImageToolName(settings: AppSettings) {
-  return settings.agentImageGenerationBackend === 'image-api' ? 'generate_image' : 'image_generation'
+function getAgentImageToolName(backend: AgentImageGenerationBackend) {
+  return backend === 'image-api' ? 'generate_image' : 'image_generation'
 }
 
-function createAgentImageInstructions(settings: AppSettings) {
-  const imageToolName = getAgentImageToolName(settings)
+function createAgentImageInstructions(backend: AgentImageGenerationBackend) {
+  const imageToolName = getAgentImageToolName(backend)
   return [
     'You are an image-generation assistant in a multi-turn gallery app.',
     '',
@@ -64,12 +64,12 @@ function createAgentImageInstructions(settings: AppSettings) {
   ].join('\n')
 }
 
-function createAgentInstructions(settings: AppSettings) {
+function createAgentInstructions(settings: AppSettings, backend: AgentImageGenerationBackend) {
   const maxToolRounds = Number.isFinite(settings.agentMaxToolRounds)
     ? Math.max(1, Math.trunc(settings.agentMaxToolRounds))
     : DEFAULT_AGENT_MAX_TOOL_ROUNDS
   const instructions = [
-    createAgentImageInstructions(settings),
+    createAgentImageInstructions(backend),
     '',
     '## Tool policy',
     `- Current maximum tool-use rounds for this Agent turn: ${maxToolRounds}.`,
@@ -129,11 +129,12 @@ function createImageTool(params: TaskParams, profile: ApiProfile, maskDataUrl?: 
 }
 
 function createAgentTools(params: TaskParams, profile: ApiProfile, settings: AppSettings, maskDataUrl?: string): Array<Record<string, unknown>> {
-  const tools: Array<Record<string, unknown>> = settings.agentImageGenerationBackend === 'image-api'
+  const backend = profile.agentImageGenerationBackend
+  const tools: Array<Record<string, unknown>> = backend === 'image-api'
     ? []
     : [createImageTool(params, profile, maskDataUrl)]
 
-  if (settings.agentImageGenerationBackend === 'image-api') {
+  if (backend === 'image-api') {
     tools.push({
       type: 'function',
       name: 'generate_image',
@@ -166,7 +167,7 @@ function createAgentTools(params: TaskParams, profile: ApiProfile, settings: App
       'Generate multiple images concurrently. Use this ONLY when:',
       '1. There are 2+ remaining images whose prerequisites (base references) are ALL already generated.',
       '2. These images are independent of each other (none references another image in this same batch).',
-      settings.agentImageGenerationBackend === 'image-api'
+      backend === 'image-api'
         ? 'For single images or prerequisite/base images, use generate_image instead.'
         : 'For single images or prerequisite/base images, use the built-in image_generation tool instead.',
       'Each image prompt must be self-contained and include full visual style descriptions.',
@@ -710,7 +711,7 @@ export async function callAgentResponsesApi(opts: {
   try {
     const body: Record<string, unknown> = {
       model: profile.model || settings.model,
-      instructions: createAgentInstructions(settings),
+      instructions: createAgentInstructions(settings, profile.agentImageGenerationBackend),
       input,
       tools: createAgentTools(params, profile, settings, maskDataUrl),
     }

--- a/src/lib/agentApi.ts
+++ b/src/lib/agentApi.ts
@@ -23,32 +23,6 @@ export interface AgentApiResult {
   rawResponsePayload?: string
 }
 
-const AGENT_IMAGE_INSTRUCTIONS = [
-  'You are an image-generation assistant in a multi-turn gallery app.',
-  '',
-  '## Progressive Batch Generation',
-  'For multi-image requests, use a progressive batching strategy to ensure consistency:',
-  '  1. **Base Reference First:** If the images need to share a consistent style, character, or layout (e.g. PPT slides, storyboards), generate ONE primary image first to establish the visual baseline, then call continue_generation to get another round.',
-  '  2. **Batch Remaining Tasks:** Once the base reference is available, list all remaining images to be generated. The app will generate them concurrently for you. In your descriptions, explicitly instruct to reference the base image to maintain consistency.',
-  '  3. **Independent Images:** If the requested images are completely independent (e.g. "3 different cats"), generate them together in ONE response. Do NOT generate them one by one across multiple responses.',
-  'As the turn continues, output a brief progress note before each tool call.',
-  'For single-image requests, generate directly without any listing.',
-  '',
-  '## Generating images',
-  '- One image_generation call per distinct image. Never collage.',
-  '- Dependent images (a later image needs to reference an earlier one) → generate the prerequisite first, then call continue_generation. The next round will have the result available as `<ref id="..." />`.',
-  '- Only generate when explicitly requested; otherwise reply with text.',
-  '- Preserve the user\'s original intent faithfully. Never substitute requested subjects for copyright/trademark reasons.',
-  '',
-  '## Reference tags and generated images in context',
-  'NEVER output `<ref>`, `<available_refs>`, `<removed_ref>`, or any XML reference tags in visible assistant text — the system injects them automatically and your raw output will be shown directly to the user.',
-  '- Previously generated images are injected as user messages containing the actual image (input_image) followed by a `<ref id="round-N-image-M" prompt="..." />` tag identifying it.',
-  '- Deleted images appear as `<removed_ref id="..." />` without an accompanying image — do not reference them.',
-  '- In user messages: `<ref id="..." />` may also point to user-attached/cited images.',
-  '- In generate_image_batch tool arguments, include matching `<ref id="..." />` tags inside each image prompt when the prompt refers to a reference image. Do not use separate bare reference ids.',
-  'Resolve user mentions ("the first image") to the matching id. Only use existing ids in image_generation prompts and generate_image_batch prompts.',
-].join('\n')
-
 const AGENT_MATH_FORMATTING_INSTRUCTIONS = [
   '## Math formatting',
   '- When a response contains mathematical formulas, output them using Markdown math delimiters supported by this app.',
@@ -57,12 +31,45 @@ const AGENT_MATH_FORMATTING_INSTRUCTIONS = [
   '- Do not use LaTeX delimiters like `\\(...\\)` or `\\[...\\]` in visible assistant text.',
 ].join('\n')
 
+function getAgentImageToolName(settings: AppSettings) {
+  return settings.agentImageGenerationBackend === 'image-api' ? 'generate_image' : 'image_generation'
+}
+
+function createAgentImageInstructions(settings: AppSettings) {
+  const imageToolName = getAgentImageToolName(settings)
+  return [
+    'You are an image-generation assistant in a multi-turn gallery app.',
+    '',
+    '## Progressive Batch Generation',
+    'For multi-image requests, use a progressive batching strategy to ensure consistency:',
+    '  1. **Base Reference First:** If the images need to share a consistent style, character, or layout (e.g. PPT slides, storyboards), generate ONE primary image first to establish the visual baseline, then call continue_generation to get another round.',
+    '  2. **Batch Remaining Tasks:** Once the base reference is available, list all remaining images to be generated. The app will generate them concurrently for you. In your descriptions, explicitly instruct to reference the base image to maintain consistency.',
+    '  3. **Independent Images:** If the requested images are completely independent (e.g. "3 different cats"), generate them together in ONE response. Do NOT generate them one by one across multiple responses.',
+    'As the turn continues, output a brief progress note before each tool call.',
+    'For single-image requests, generate directly without any listing.',
+    '',
+    '## Generating images',
+    `- One ${imageToolName} call per distinct image. Never collage.`,
+    `- Dependent images (a later image needs to reference an earlier one) → generate the prerequisite first with ${imageToolName}, then call continue_generation. The next round will have the result available as \`<ref id="..." />\`.`,
+    '- Only generate when explicitly requested; otherwise reply with text.',
+    '- Preserve the user\'s original intent faithfully. Never substitute requested subjects for copyright/trademark reasons.',
+    '',
+    '## Reference tags and generated images in context',
+    'NEVER output `<ref>`, `<available_refs>`, `<removed_ref>`, or any XML reference tags in visible assistant text — the system injects them automatically and your raw output will be shown directly to the user.',
+    '- Previously generated images are injected as user messages containing the actual image (input_image) followed by a `<ref id="round-N-image-M" prompt="..." />` tag identifying it.',
+    '- Deleted images appear as `<removed_ref id="..." />` without an accompanying image — do not reference them.',
+    '- In user messages: `<ref id="..." />` may also point to user-attached/cited images.',
+    '- In generate_image and generate_image_batch tool arguments, include matching `<ref id="..." />` tags inside each image prompt when the prompt refers to a reference image. Do not use separate bare reference ids.',
+    `Resolve user mentions ("the first image") to the matching id. Only use existing ids in ${imageToolName} prompts and generate_image_batch prompts.`,
+  ].join('\n')
+}
+
 function createAgentInstructions(settings: AppSettings) {
   const maxToolRounds = Number.isFinite(settings.agentMaxToolRounds)
     ? Math.max(1, Math.trunc(settings.agentMaxToolRounds))
     : DEFAULT_AGENT_MAX_TOOL_ROUNDS
   const instructions = [
-    AGENT_IMAGE_INSTRUCTIONS,
+    createAgentImageInstructions(settings),
     '',
     '## Tool policy',
     `- Current maximum tool-use rounds for this Agent turn: ${maxToolRounds}.`,
@@ -122,7 +129,34 @@ function createImageTool(params: TaskParams, profile: ApiProfile, maskDataUrl?: 
 }
 
 function createAgentTools(params: TaskParams, profile: ApiProfile, settings: AppSettings, maskDataUrl?: string): Array<Record<string, unknown>> {
-  const tools: Array<Record<string, unknown>> = [createImageTool(params, profile, maskDataUrl)]
+  const tools: Array<Record<string, unknown>> = settings.agentImageGenerationBackend === 'image-api'
+    ? []
+    : [createImageTool(params, profile, maskDataUrl)]
+
+  if (settings.agentImageGenerationBackend === 'image-api') {
+    tools.push({
+      type: 'function',
+      name: 'generate_image',
+      description: [
+        'Generate one image using the app configured Image API backend.',
+        'Use this for single-image requests or prerequisite/base images that later images must reference.',
+        'The prompt must be self-contained and include full visual details.',
+        'If the image needs to match a previous image, include the corresponding XML tag (e.g. <ref id="round-1-image-1" />) inside the prompt so the app can attach the reference image automatically.',
+      ].join(' '),
+      parameters: {
+        type: 'object',
+        properties: {
+          prompt: {
+            type: 'string',
+            description: 'Complete image generation prompt with all visual details and any needed <ref id="..." /> tags.',
+          },
+        },
+        required: ['prompt'],
+        additionalProperties: false,
+      },
+      strict: true,
+    })
+  }
 
   // generate_image_batch: custom function tool for concurrent multi-image generation
   tools.push({
@@ -132,7 +166,9 @@ function createAgentTools(params: TaskParams, profile: ApiProfile, settings: App
       'Generate multiple images concurrently. Use this ONLY when:',
       '1. There are 2+ remaining images whose prerequisites (base references) are ALL already generated.',
       '2. These images are independent of each other (none references another image in this same batch).',
-      'For single images or prerequisite/base images, use the built-in image_generation tool instead.',
+      settings.agentImageGenerationBackend === 'image-api'
+        ? 'For single images or prerequisite/base images, use generate_image instead.'
+        : 'For single images or prerequisite/base images, use the built-in image_generation tool instead.',
       'Each image prompt must be self-contained and include full visual style descriptions.',
       'If an image needs to match a previously generated image, include the corresponding XML tag (e.g. <ref id="round-1-image-1" />) inside that image prompt so the app can attach the reference image automatically.',
     ].join(' '),

--- a/src/lib/apiProfiles.test.ts
+++ b/src/lib/apiProfiles.test.ts
@@ -650,6 +650,33 @@ describe('custom providers', () => {
     expect(normalizeSettings({ agentMathFormattingPrompt: false }).agentMathFormattingPrompt).toBe(false)
   })
 
+  it('normalizes Agent image generation configuration', () => {
+    const settings = normalizeSettings({
+      agentImageGenerationBackend: 'image-api',
+      agentImageApiProfile: {
+        id: 'agent-image-api',
+        name: 'Agent Images',
+        provider: 'openai',
+        baseUrl: 'https://images.example.com/v1',
+        apiKey: 'image-key',
+        model: 'image-model',
+        apiMode: 'responses',
+        streamImages: true,
+      },
+    })
+
+    expect(settings.agentImageGenerationBackend).toBe('image-api')
+    expect(settings.agentImageApiProfile).toMatchObject({
+      id: 'agent-image-api',
+      name: 'Agent Images',
+      baseUrl: 'https://images.example.com/v1',
+      apiKey: 'image-key',
+      model: 'image-model',
+      apiMode: 'images',
+      streamImages: false,
+    })
+  })
+
   it('restores OpenAI-compatible URL after switching through fal.ai', () => {
     const openaiProfile = createDefaultOpenAIProfile({
       baseUrl: 'https://api.compat.example.com/v1',

--- a/src/lib/apiProfiles.test.ts
+++ b/src/lib/apiProfiles.test.ts
@@ -650,11 +650,11 @@ describe('custom providers', () => {
     expect(normalizeSettings({ agentMathFormattingPrompt: false }).agentMathFormattingPrompt).toBe(false)
   })
 
-  it('normalizes Agent image generation configuration', () => {
+  it('normalizes image generation configuration', () => {
     const settings = normalizeSettings({
       agentImageGenerationBackend: 'image-api',
-      agentImageApiProfile: {
-        id: 'agent-image-api',
+      imageApiProfile: {
+        id: 'image-api',
         name: 'Agent Images',
         provider: 'openai',
         baseUrl: 'https://images.example.com/v1',
@@ -666,8 +666,8 @@ describe('custom providers', () => {
     })
 
     expect(settings.agentImageGenerationBackend).toBe('image-api')
-    expect(settings.agentImageApiProfile).toMatchObject({
-      id: 'agent-image-api',
+    expect(settings.imageApiProfile).toMatchObject({
+      id: 'image-api',
       name: 'Agent Images',
       baseUrl: 'https://images.example.com/v1',
       apiKey: 'image-key',

--- a/src/lib/apiProfiles.test.ts
+++ b/src/lib/apiProfiles.test.ts
@@ -665,8 +665,9 @@ describe('custom providers', () => {
       },
     })
 
-    expect(settings.agentImageGenerationBackend).toBe('image-api')
-    expect(settings.imageApiProfile).toMatchObject({
+    const profile = settings.profiles[0]
+    expect(profile.agentImageGenerationBackend).toBe('image-api')
+    expect(profile.imageApiProfile).toMatchObject({
       id: 'image-api',
       name: 'Agent Images',
       baseUrl: 'https://images.example.com/v1',

--- a/src/lib/apiProfiles.ts
+++ b/src/lib/apiProfiles.ts
@@ -3,6 +3,7 @@ import type {
   ApiProfile,
   ApiProvider,
   AppSettings,
+  AgentImageGenerationBackend,
   CustomProviderContentType,
   CustomProviderDefinition,
   CustomProviderFileMapping,
@@ -472,6 +473,28 @@ export function normalizeApiProfile(input: unknown, fallback?: Partial<ApiProfil
   }
 }
 
+function normalizeAgentImageGenerationBackend(value: unknown): AgentImageGenerationBackend {
+  return value === 'image-api' ? 'image-api' : 'native'
+}
+
+function normalizeAgentImageApiProfile(input: unknown, customProviderIds: Set<string>): ApiProfile {
+  const profile = normalizeApiProfile(input, {
+    id: 'agent-image-api',
+    name: 'Agent 图像生成',
+    apiMode: 'images',
+    model: DEFAULT_IMAGES_MODEL,
+    streamImages: false,
+  }, customProviderIds)
+
+  return {
+    ...profile,
+    id: profile.id || 'agent-image-api',
+    name: profile.name || 'Agent 图像生成',
+    apiMode: 'images',
+    streamImages: false,
+  }
+}
+
 function validateImportedProfileRecord(input: unknown) {
   if (!isRecord(input)) return
 
@@ -509,6 +532,8 @@ export function normalizeSettings(input: Partial<AppSettings> | unknown): AppSet
     ? record.activeProfileId
     : profiles[0].id
   const active = profiles.find((p) => p.id === activeProfileId) ?? profiles[0]
+  const agentImageGenerationBackend = normalizeAgentImageGenerationBackend(record.agentImageGenerationBackend)
+  const agentImageApiProfile = normalizeAgentImageApiProfile(record.agentImageApiProfile, customProviderIds)
 
   return {
     baseUrl: active.baseUrl,
@@ -534,6 +559,8 @@ export function normalizeSettings(input: Partial<AppSettings> | unknown): AppSet
     agentMaxToolRounds: normalizeAgentMaxToolRounds(record.agentMaxToolRounds),
     agentWebSearch: typeof record.agentWebSearch === 'boolean' ? record.agentWebSearch : false,
     agentMathFormattingPrompt: typeof record.agentMathFormattingPrompt === 'boolean' ? record.agentMathFormattingPrompt : true,
+    agentImageGenerationBackend,
+    agentImageApiProfile,
     profiles,
     activeProfileId,
   }
@@ -826,4 +853,11 @@ export const DEFAULT_SETTINGS: AppSettings = normalizeSettings({
   agentMaxToolRounds: DEFAULT_AGENT_MAX_TOOL_ROUNDS,
   agentWebSearch: false,
   agentMathFormattingPrompt: true,
+  agentImageGenerationBackend: 'native',
+  agentImageApiProfile: createDefaultOpenAIProfile({
+    id: 'agent-image-api',
+    name: 'Agent 图像生成',
+    apiMode: 'images',
+    streamImages: false,
+  }),
 })

--- a/src/lib/apiProfiles.ts
+++ b/src/lib/apiProfiles.ts
@@ -477,10 +477,10 @@ function normalizeAgentImageGenerationBackend(value: unknown): AgentImageGenerat
   return value === 'image-api' ? 'image-api' : 'native'
 }
 
-function normalizeAgentImageApiProfile(input: unknown, customProviderIds: Set<string>): ApiProfile {
+function normalizeImageApiProfile(input: unknown, customProviderIds: Set<string>): ApiProfile {
   const profile = normalizeApiProfile(input, {
-    id: 'agent-image-api',
-    name: 'Agent 图像生成',
+    id: 'image-api',
+    name: '图像生成',
     apiMode: 'images',
     model: DEFAULT_IMAGES_MODEL,
     streamImages: false,
@@ -488,8 +488,8 @@ function normalizeAgentImageApiProfile(input: unknown, customProviderIds: Set<st
 
   return {
     ...profile,
-    id: profile.id || 'agent-image-api',
-    name: profile.name || 'Agent 图像生成',
+    id: profile.id || 'image-api',
+    name: profile.name || '图像生成',
     apiMode: 'images',
     streamImages: false,
   }
@@ -533,7 +533,7 @@ export function normalizeSettings(input: Partial<AppSettings> | unknown): AppSet
     : profiles[0].id
   const active = profiles.find((p) => p.id === activeProfileId) ?? profiles[0]
   const agentImageGenerationBackend = normalizeAgentImageGenerationBackend(record.agentImageGenerationBackend)
-  const agentImageApiProfile = normalizeAgentImageApiProfile(record.agentImageApiProfile, customProviderIds)
+  const imageApiProfile = normalizeImageApiProfile(record.imageApiProfile, customProviderIds)
 
   return {
     baseUrl: active.baseUrl,
@@ -560,7 +560,7 @@ export function normalizeSettings(input: Partial<AppSettings> | unknown): AppSet
     agentWebSearch: typeof record.agentWebSearch === 'boolean' ? record.agentWebSearch : false,
     agentMathFormattingPrompt: typeof record.agentMathFormattingPrompt === 'boolean' ? record.agentMathFormattingPrompt : true,
     agentImageGenerationBackend,
-    agentImageApiProfile,
+    imageApiProfile,
     profiles,
     activeProfileId,
   }
@@ -854,9 +854,9 @@ export const DEFAULT_SETTINGS: AppSettings = normalizeSettings({
   agentWebSearch: false,
   agentMathFormattingPrompt: true,
   agentImageGenerationBackend: 'native',
-  agentImageApiProfile: createDefaultOpenAIProfile({
-    id: 'agent-image-api',
-    name: 'Agent 图像生成',
+  imageApiProfile: createDefaultOpenAIProfile({
+    id: 'image-api',
+    name: '图像生成',
     apiMode: 'images',
     streamImages: false,
   }),

--- a/src/lib/apiProfiles.ts
+++ b/src/lib/apiProfiles.ts
@@ -822,11 +822,20 @@ export function mergeImportedSettings(currentSettings: Partial<AppSettings> | un
     }))
   const profiles = [...current.profiles, ...importedProfiles]
 
+  const imageApiProfile = imported.imageApiProfile?.apiKey?.trim()
+    ? imported.imageApiProfile
+    : current.imageApiProfile
+  const agentImageGenerationBackend = imported.agentImageGenerationBackend === 'image-api'
+    ? 'image-api' as const
+    : current.agentImageGenerationBackend
+
   return normalizeSettings({
     ...current,
     customProviders,
     profiles,
     activeProfileId: current.activeProfileId,
+    imageApiProfile,
+    agentImageGenerationBackend,
   })
 }
 

--- a/src/lib/apiProfiles.ts
+++ b/src/lib/apiProfiles.ts
@@ -313,6 +313,7 @@ export function createDefaultOpenAIProfile(overrides: Partial<ApiProfile> = {}):
     codexCli: false,
     apiProxy: DEFAULT_OPENAI_API_PROXY,
     streamPartialImages: DEFAULT_STREAM_PARTIAL_IMAGES,
+    agentImageGenerationBackend: 'native',
     ...overrides,
     apiMode,
     streamImages,
@@ -333,6 +334,7 @@ export function createDefaultFalProfile(overrides: Partial<ApiProfile> = {}): Ap
     apiProxy: false,
     streamImages: false,
     streamPartialImages: DEFAULT_STREAM_PARTIAL_IMAGES,
+    agentImageGenerationBackend: 'native',
     ...overrides,
   }
 }
@@ -453,6 +455,7 @@ export function normalizeApiProfile(input: unknown, fallback?: Partial<ApiProfil
   const streamImages = provider === 'openai'
     ? typeof record.streamImages === 'boolean' ? record.streamImages : defaults.streamImages
     : false
+  const hasImageApiProfile = 'imageApiProfile' in record
 
   return {
     ...defaults,
@@ -470,6 +473,8 @@ export function normalizeApiProfile(input: unknown, fallback?: Partial<ApiProfil
     streamImages,
     streamPartialImages: normalizeStreamPartialImages(record.streamPartialImages, defaults.streamPartialImages),
     providerDrafts: normalizeProviderDrafts(record.providerDrafts, customProviderIds),
+    agentImageGenerationBackend: normalizeAgentImageGenerationBackend(record.agentImageGenerationBackend),
+    ...(hasImageApiProfile ? { imageApiProfile: normalizeImageApiProfile(record.imageApiProfile, customProviderIds) } : {}),
   }
 }
 
@@ -478,20 +483,30 @@ function normalizeAgentImageGenerationBackend(value: unknown): AgentImageGenerat
 }
 
 function normalizeImageApiProfile(input: unknown, customProviderIds: Set<string>): ApiProfile {
-  const profile = normalizeApiProfile(input, {
-    id: 'image-api',
-    name: '图像生成',
-    apiMode: 'images',
-    model: DEFAULT_IMAGES_MODEL,
-    streamImages: false,
-  }, customProviderIds)
+  const record = input && typeof input === 'object' ? input as Record<string, unknown> : {}
+  const rawProvider = typeof record.provider === 'string' ? record.provider : ''
+  const provider: ApiProvider = rawProvider === 'fal' || customProviderIds.has(rawProvider) ? rawProvider : 'openai'
+  const defaults = provider === 'fal'
+    ? createDefaultFalProfile({ apiMode: 'images', streamImages: false })
+    : createDefaultOpenAIProfile({ apiMode: 'images', streamImages: false })
+  const rawBaseUrl = typeof record.baseUrl === 'string' ? record.baseUrl : defaults.baseUrl
 
   return {
-    ...profile,
-    id: profile.id || 'image-api',
-    name: profile.name || '图像生成',
+    ...defaults,
+    id: typeof record.id === 'string' && record.id.trim() ? record.id : 'image-api',
+    name: typeof record.name === 'string' && record.name.trim() ? record.name : '图像生成',
+    provider,
+    baseUrl: provider === 'fal' ? rawBaseUrl.trim().replace(/\/+$/, '') || DEFAULT_FAL_BASE_URL : rawBaseUrl,
+    apiKey: typeof record.apiKey === 'string' ? record.apiKey : defaults.apiKey,
+    model: typeof record.model === 'string' && record.model.trim() ? record.model : DEFAULT_IMAGES_MODEL,
+    timeout: typeof record.timeout === 'number' && Number.isFinite(record.timeout) ? record.timeout : defaults.timeout,
     apiMode: 'images',
+    codexCli: false,
+    apiProxy: typeof record.apiProxy === 'boolean' ? record.apiProxy : false,
+    responseFormatB64Json: record.responseFormatB64Json === true ? true : undefined,
     streamImages: false,
+    streamPartialImages: DEFAULT_STREAM_PARTIAL_IMAGES,
+    agentImageGenerationBackend: 'native' as const,
   }
 }
 
@@ -524,16 +539,32 @@ export function normalizeSettings(input: Partial<AppSettings> | unknown): AppSet
     responseFormatB64Json: record.responseFormatB64Json === true ? true : undefined,
     streamImages: typeof record.streamImages === 'boolean' ? record.streamImages : undefined,
     streamPartialImages: normalizeStreamPartialImages(record.streamPartialImages),
+    // 确保有默认 imageApiProfile
+    imageApiProfile: {} as ApiProfile,
   })
   const profiles = Array.isArray(record.profiles) && record.profiles.length
     ? record.profiles.map((profile) => normalizeApiProfile(profile, undefined, customProviderIds))
-    : [legacyProfile]
+    : [normalizeApiProfile(legacyProfile, undefined, customProviderIds)]
   const activeProfileId = typeof record.activeProfileId === 'string' && profiles.some((p) => p.id === record.activeProfileId)
     ? record.activeProfileId
     : profiles[0].id
   const active = profiles.find((p) => p.id === activeProfileId) ?? profiles[0]
-  const agentImageGenerationBackend = normalizeAgentImageGenerationBackend(record.agentImageGenerationBackend)
-  const imageApiProfile = normalizeImageApiProfile(record.imageApiProfile, customProviderIds)
+
+  // 迁移旧格式：顶层 imageApiProfile / agentImageGenerationBackend → 注入当前活跃 profile
+  if (isRecord(record)) {
+    const hasLegacyImageApiProfile = record.imageApiProfile && typeof record.imageApiProfile === 'object'
+    const hasLegacyBackend = typeof record.agentImageGenerationBackend === 'string'
+    if (hasLegacyImageApiProfile || hasLegacyBackend) {
+      const activeIndex = profiles.findIndex((p) => p.id === activeProfileId)
+      if (activeIndex >= 0) {
+        profiles[activeIndex] = {
+          ...profiles[activeIndex],
+          ...(hasLegacyBackend ? { agentImageGenerationBackend: normalizeAgentImageGenerationBackend(record.agentImageGenerationBackend) } : {}),
+          ...(hasLegacyImageApiProfile ? { imageApiProfile: normalizeImageApiProfile(record.imageApiProfile, customProviderIds) } : {}),
+        }
+      }
+    }
+  }
 
   return {
     baseUrl: active.baseUrl,
@@ -559,8 +590,6 @@ export function normalizeSettings(input: Partial<AppSettings> | unknown): AppSet
     agentMaxToolRounds: normalizeAgentMaxToolRounds(record.agentMaxToolRounds),
     agentWebSearch: typeof record.agentWebSearch === 'boolean' ? record.agentWebSearch : false,
     agentMathFormattingPrompt: typeof record.agentMathFormattingPrompt === 'boolean' ? record.agentMathFormattingPrompt : true,
-    agentImageGenerationBackend,
-    imageApiProfile,
     profiles,
     activeProfileId,
   }
@@ -822,20 +851,11 @@ export function mergeImportedSettings(currentSettings: Partial<AppSettings> | un
     }))
   const profiles = [...current.profiles, ...importedProfiles]
 
-  const imageApiProfile = imported.imageApiProfile?.apiKey?.trim()
-    ? imported.imageApiProfile
-    : current.imageApiProfile
-  const agentImageGenerationBackend = imported.agentImageGenerationBackend === 'image-api'
-    ? 'image-api' as const
-    : current.agentImageGenerationBackend
-
   return normalizeSettings({
     ...current,
     customProviders,
     profiles,
     activeProfileId: current.activeProfileId,
-    imageApiProfile,
-    agentImageGenerationBackend,
   })
 }
 
@@ -862,11 +882,4 @@ export const DEFAULT_SETTINGS: AppSettings = normalizeSettings({
   agentMaxToolRounds: DEFAULT_AGENT_MAX_TOOL_ROUNDS,
   agentWebSearch: false,
   agentMathFormattingPrompt: true,
-  agentImageGenerationBackend: 'native',
-  imageApiProfile: createDefaultOpenAIProfile({
-    id: 'image-api',
-    name: '图像生成',
-    apiMode: 'images',
-    streamImages: false,
-  }),
 })

--- a/src/lib/urlSettings.ts
+++ b/src/lib/urlSettings.ts
@@ -1,4 +1,4 @@
-import type { ApiMode, AppSettings } from '../types'
+import type { ApiMode, ApiProfile, AppSettings } from '../types'
 import { normalizeBaseUrl } from './devProxy'
 import {
   createDefaultOpenAIProfile,
@@ -138,22 +138,20 @@ function buildDefaultConfigOnlySettingsFromUrlParams(currentSettings: Partial<Ap
     if (streamPartialImagesParam !== null) patch.streamPartialImages = normalizeStreamPartialImages(streamPartialImagesParam)
   }
 
-  // 从 ?settings= JSON 中提取 imageApiProfile 和 agentImageGenerationBackend
+  // 从 ?settings= JSON 中提取 imageApiProfile 和 agentImageGenerationBackend，注入到活跃 profile
   const imported = importedSettings as Record<string, unknown> | null
-  const settingsPatch: Partial<AppSettings> = {}
   if (imported?.agentImageGenerationBackend === 'image-api') {
-    settingsPatch.agentImageGenerationBackend = 'image-api'
+    patch.agentImageGenerationBackend = 'image-api'
   }
   const rawImageProfile = imported?.imageApiProfile
   if (rawImageProfile && typeof rawImageProfile === 'object' && !Array.isArray(rawImageProfile)) {
-    settingsPatch.imageApiProfile = rawImageProfile as AppSettings['imageApiProfile']
+    patch.imageApiProfile = rawImageProfile as ApiProfile
   }
 
-  if (Object.keys(patch).length === 0 && Object.keys(settingsPatch).length === 0) return {}
+  if (Object.keys(patch).length === 0) return {}
 
   return normalizeSettings({
     ...settings,
-    ...settingsPatch,
     profiles: settings.profiles.map((profile) =>
       profile.id === activeProfile.id ? { ...profile, ...patch, provider: profile.provider } : profile,
     ),

--- a/src/lib/urlSettings.ts
+++ b/src/lib/urlSettings.ts
@@ -40,6 +40,8 @@ function pickUrlSettingsPayload(value: unknown): unknown | null {
   return {
     customProviders: record.customProviders,
     profiles: record.profiles,
+    imageApiProfile: record.imageApiProfile,
+    agentImageGenerationBackend: record.agentImageGenerationBackend,
   }
 }
 
@@ -136,10 +138,22 @@ function buildDefaultConfigOnlySettingsFromUrlParams(currentSettings: Partial<Ap
     if (streamPartialImagesParam !== null) patch.streamPartialImages = normalizeStreamPartialImages(streamPartialImagesParam)
   }
 
-  if (Object.keys(patch).length === 0) return {}
+  // 从 ?settings= JSON 中提取 imageApiProfile 和 agentImageGenerationBackend
+  const imported = importedSettings as Record<string, unknown> | null
+  const settingsPatch: Partial<AppSettings> = {}
+  if (imported?.agentImageGenerationBackend === 'image-api') {
+    settingsPatch.agentImageGenerationBackend = 'image-api'
+  }
+  const rawImageProfile = imported?.imageApiProfile
+  if (rawImageProfile && typeof rawImageProfile === 'object' && !Array.isArray(rawImageProfile)) {
+    settingsPatch.imageApiProfile = rawImageProfile as AppSettings['imageApiProfile']
+  }
+
+  if (Object.keys(patch).length === 0 && Object.keys(settingsPatch).length === 0) return {}
 
   return normalizeSettings({
     ...settings,
+    ...settingsPatch,
     profiles: settings.profiles.map((profile) =>
       profile.id === activeProfile.id ? { ...profile, ...patch, provider: profile.provider } : profile,
     ),

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -238,11 +238,12 @@ describe('favorite collection deletion', () => {
 
 describe('mask draft lifecycle in store actions', () => {
   beforeEach(() => {
+    const imageProfile = { ...DEFAULT_SETTINGS.profiles[0].imageApiProfile!, apiKey: 'test-key' }
     useStore.setState({
       settings: normalizeSettings({
         ...DEFAULT_SETTINGS,
         apiKey: 'test-key',
-        imageApiProfile: { ...DEFAULT_SETTINGS.imageApiProfile, apiKey: 'test-key' },
+        profiles: DEFAULT_SETTINGS.profiles.map((p) => ({ ...p, imageApiProfile: imageProfile })),
       }),
       prompt: 'prompt',
       inputImages: [],
@@ -452,9 +453,7 @@ describe('mask draft lifecycle in store actions', () => {
     useStore.setState({
       settings: normalizeSettings({
         ...DEFAULT_SETTINGS,
-        profiles: [falProfile],
-        activeProfileId: falProfile.id,
-        imageApiProfile: { ...falProfile, apiMode: 'images' as const, streamImages: false },
+        profiles: [{ ...falProfile, imageApiProfile: { ...falProfile, apiMode: 'images' as const, streamImages: false } }],
       }),
       prompt: '单主体图标素材',
       params: {
@@ -2098,8 +2097,11 @@ describe('agent batch reference resolution', () => {
     useStore.setState({
       settings: normalizeSettings({
         ...useStore.getState().settings,
-        agentImageGenerationBackend: 'image-api',
-        imageApiProfile: imageProfile,
+        profiles: useStore.getState().settings.profiles.map((p) => ({
+          ...p,
+          agentImageGenerationBackend: 'image-api' as const,
+          imageApiProfile: imageProfile,
+        })),
       }),
     })
     vi.mocked(callImageApi).mockClear()

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -129,6 +129,7 @@ vi.mock('./lib/agentApi', () => ({
 }))
 import { clearAgentConversations, clearImages, clearTasks, getAllAgentConversations, getAllTasks, getImage, putAgentConversation, putImage, putTask as putDbTask } from './lib/db'
 import { callAgentResponsesApi, callBatchImageSingle } from './lib/agentApi'
+import { callImageApi } from './lib/api'
 import { getFalQueuedImageResult } from './lib/falAiImageApi'
 import { removeKeyedBackgroundFromDataUrl } from './lib/transparentImage'
 import { cleanStaleAgentInputDrafts, clearFailedTasks, deleteAgentRoundFromConversation, deleteFavoriteCollection, editOutputs, getActiveAgentRounds, getErrorToastMessage, getPersistedState, getTaskApiProfile, importData, initStore, markInterruptedOpenAIRunningTasks, migratePersistedState, regenerateAgentAssistantMessage, remapAgentRoundMentionsForPathChange, removeTask, reuseConfig, submitAgentMessage, submitTask, taskMatchesFilterStatus, taskMatchesSearchQuery, useStore } from './store'
@@ -2079,6 +2080,69 @@ describe('agent batch reference resolution', () => {
     const batchArgs = vi.mocked(callBatchImageSingle).mock.calls[0][0]
     expect(batchArgs.referenceImageDataUrls).toEqual([imageA.dataUrl])
     expect(batchArgs.referenceIds).toEqual(['round-3-reference-1'])
+  })
+
+  it('uses configured Image API profile for Agent client image tools', async () => {
+    const imageProfile = createDefaultOpenAIProfile({
+      id: 'agent-image-profile',
+      name: 'Agent Images',
+      apiKey: 'image-key',
+      apiMode: 'images',
+      model: 'image-model',
+    })
+    useStore.setState({
+      settings: normalizeSettings({
+        ...useStore.getState().settings,
+        agentImageGenerationBackend: 'image-api',
+        agentImageApiProfile: imageProfile,
+      }),
+    })
+    vi.mocked(callImageApi).mockClear()
+    vi.mocked(callImageApi).mockResolvedValueOnce({
+      images: ['data:image/png;base64,agent-image-api-output'],
+      actualParams: { size: '1024x1024' },
+      actualParamsList: [{ size: '1024x1024' }],
+      revisedPrompts: ['image api prompt'],
+    })
+    vi.mocked(callBatchImageSingle).mockClear()
+    vi.mocked(callAgentResponsesApi)
+      .mockResolvedValueOnce({
+        text: '',
+        images: [],
+        outputItems: [{
+          type: 'function_call',
+          name: 'generate_image',
+          call_id: 'single-image-call',
+          arguments: JSON.stringify({ prompt: '参考 <ref id="round-3-reference-1" /> 生成单图' }),
+        }],
+        responseId: 'response-1',
+      })
+      .mockResolvedValueOnce({
+        text: '完成',
+        images: [],
+        outputItems: [{ type: 'message', content: [{ type: 'output_text', text: '完成' }] }],
+        responseId: 'response-2',
+      })
+    useStore.setState({ inputImages: [imageA] })
+
+    await submitAgentMessage()
+
+    for (let i = 0; i < 10 && vi.mocked(callImageApi).mock.calls.length === 0; i++) {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+    expect(callImageApi).toHaveBeenCalled()
+    expect(callBatchImageSingle).not.toHaveBeenCalled()
+    const imageCallArgs = vi.mocked(callImageApi).mock.calls[0][0]
+    expect(imageCallArgs.settings.activeProfileId).toBe(imageProfile.id)
+    expect(imageCallArgs.settings.model).toBe('image-model')
+    expect(imageCallArgs.inputImageDataUrls).toEqual([imageA.dataUrl])
+    const generatedTask = useStore.getState().tasks.find((item) => item.apiProfileId === imageProfile.id)
+    expect(generatedTask).toMatchObject({
+      apiProfileName: 'Agent Images',
+      apiMode: 'images',
+      apiModel: 'image-model',
+      status: 'done',
+    })
   })
 })
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -239,7 +239,11 @@ describe('favorite collection deletion', () => {
 describe('mask draft lifecycle in store actions', () => {
   beforeEach(() => {
     useStore.setState({
-      settings: { ...DEFAULT_SETTINGS, apiKey: 'test-key' },
+      settings: normalizeSettings({
+        ...DEFAULT_SETTINGS,
+        apiKey: 'test-key',
+        imageApiProfile: { ...DEFAULT_SETTINGS.imageApiProfile, apiKey: 'test-key' },
+      }),
       prompt: 'prompt',
       inputImages: [],
       maskDraft: null,
@@ -450,6 +454,7 @@ describe('mask draft lifecycle in store actions', () => {
         ...DEFAULT_SETTINGS,
         profiles: [falProfile],
         activeProfileId: falProfile.id,
+        imageApiProfile: { ...falProfile, apiMode: 'images' as const, streamImages: false },
       }),
       prompt: '单主体图标素材',
       params: {
@@ -2094,7 +2099,7 @@ describe('agent batch reference resolution', () => {
       settings: normalizeSettings({
         ...useStore.getState().settings,
         agentImageGenerationBackend: 'image-api',
-        agentImageApiProfile: imageProfile,
+        imageApiProfile: imageProfile,
       }),
     })
     vi.mocked(callImageApi).mockClear()
@@ -2380,7 +2385,7 @@ describe('reused task API profile', () => {
     expect(state.tasks).toEqual([])
     expect(state.setConfirmDialog).toHaveBeenCalledWith(expect.objectContaining({
       title: '找不到 API 配置',
-      message: '找不到复用任务所使用的 API 配置「未知配置」，要使用当前的 API 配置「默认」提交任务吗？',
+      message: '找不到复用任务所使用的 API 配置「未知配置」，要使用当前的图像生成配置「图像生成」提交任务吗？',
       confirmText: '使用当前配置提交',
       cancelText: '放弃提交',
     }))

--- a/src/store.ts
+++ b/src/store.ts
@@ -1675,7 +1675,7 @@ function putTask(task: TaskRecord): Promise<IDBValidKey> {
 }
 
 export function getCodexCliPromptKey(settings: AppSettings): string {
-  const profile = normalizeSettings(settings).imageApiProfile
+  const profile = getImageApiProfile(settings)
   return `${profile.baseUrl}\n${profile.apiKey}`
 }
 
@@ -1838,9 +1838,15 @@ function createSettingsForApiProfile(settings: AppSettings, profile: ApiProfile)
   })
 }
 
+function getImageApiProfile(settings: AppSettings): ApiProfile {
+  return getActiveApiProfile(settings).imageApiProfile
+    ?? normalizeSettings(settings).profiles[0]?.imageApiProfile
+    ?? normalizeSettings({}).profiles[0].imageApiProfile!
+}
+
 function createSettingsForImageApiProfile(settings: AppSettings): AppSettings {
   const normalized = normalizeSettings(settings)
-  return createSettingsForApiProfile(normalized, normalized.imageApiProfile)
+  return createSettingsForApiProfile(normalized, getImageApiProfile(normalized))
 }
 
 function getReusedTaskApiProfile(settings: AppSettings, profileId: string | null): ApiProfile | null {
@@ -2296,11 +2302,12 @@ export async function submitTask(options: { allowFullMask?: boolean; useCurrentA
     useStore.getState()
 
   const normalizedSettings = normalizeSettings(settings)
-  let activeProfile: ApiProfile = normalizedSettings.imageApiProfile
+  const imageProfile = getImageApiProfile(normalizedSettings)
+  let activeProfile: ApiProfile = imageProfile
   let requestSettings = createSettingsForApiProfile(normalizedSettings, activeProfile)
   if (normalizedSettings.reuseTaskApiProfileTemporarily && (reusedTaskApiProfileId || reusedTaskApiProfileMissing)) {
-    const reusedProfile = reusedTaskApiProfileId === normalizedSettings.imageApiProfile.id
-      ? normalizedSettings.imageApiProfile
+    const reusedProfile = reusedTaskApiProfileId === imageProfile.id
+      ? imageProfile
       : getReusedTaskApiProfile(normalizedSettings, reusedTaskApiProfileId)
     if (!reusedProfile) {
       if (options.useCurrentApiProfileWhenReusedMissing) {
@@ -3227,8 +3234,8 @@ export async function submitAgentMessage() {
     return
   }
 
-  if (normalizedSettings.agentImageGenerationBackend === 'image-api') {
-    const imageProfileError = validateApiProfile(normalizedSettings.imageApiProfile)
+  if (activeProfile.agentImageGenerationBackend === 'image-api') {
+    const imageProfileError = validateApiProfile(activeProfile.imageApiProfile!)
     if (imageProfileError) {
       showToast(`请先完善图像生成配置：${imageProfileError}`, 'error')
       state.setShowSettings(true, 'api')
@@ -3387,8 +3394,8 @@ export async function regenerateAgentAssistantMessage(conversationId: string, ro
     return
   }
 
-  if (normalizedSettings.agentImageGenerationBackend === 'image-api') {
-    const imageProfileError = validateApiProfile(normalizedSettings.imageApiProfile)
+  if (activeProfile.agentImageGenerationBackend === 'image-api') {
+    const imageProfileError = validateApiProfile(activeProfile.imageApiProfile!)
     if (imageProfileError) {
       showToast(`请先完善图像生成配置：${imageProfileError}`, 'error')
       state.setShowSettings(true, 'api')
@@ -3661,7 +3668,7 @@ async function executeAgentRound(
     const maxToolCalls = Number.isFinite(requestSettings.agentMaxToolRounds)
       ? Math.max(1, Math.trunc(requestSettings.agentMaxToolRounds))
       : DEFAULT_AGENT_MAX_TOOL_ROUNDS
-    const useAgentImageApi = requestSettings.agentImageGenerationBackend === 'image-api'
+    const useAgentImageApi = activeProfile.agentImageGenerationBackend === 'image-api'
     const imageApiSettings = useAgentImageApi ? createSettingsForImageApiProfile(requestSettings) : null
     const imageApiProfile = imageApiSettings ? getActiveApiProfile(imageApiSettings) : null
     let apiInputForTurn = apiInput
@@ -4276,8 +4283,9 @@ async function executeTask(taskId: string) {
   const { settings } = useStore.getState()
   const task = useStore.getState().tasks.find((t) => t.id === taskId)
   if (!task) return
+  const imageProfile = getImageApiProfile(settings)
   const taskProfile = getTaskApiProfile(settings, task)
-    ?? (task.apiProfileId === normalizeSettings(settings).imageApiProfile.id ? normalizeSettings(settings).imageApiProfile : null)
+    ?? (task.apiProfileId === imageProfile.id ? imageProfile : null)
   if (!taskProfile && task.apiProfileId) {
     updateTaskInStore(taskId, {
       status: 'error',
@@ -4289,7 +4297,7 @@ async function executeTask(taskId: string) {
     })
     return
   }
-  const activeProfile = taskProfile ?? normalizeSettings(settings).imageApiProfile
+  const activeProfile = taskProfile ?? imageProfile
   const requestSettings = createSettingsForApiProfile(settings, activeProfile)
   const taskProvider = task.apiProvider ?? activeProfile.provider
   let falRequestInfo: { requestId: string; endpoint: string } | null = task.falRequestId && task.falEndpoint
@@ -4469,10 +4477,10 @@ async function executeTask(taskId: string) {
     } else {
       let errorMessage = err instanceof Error ? err.message : String(err)
       const settings = useStore.getState().settings
+      const imageProfile = getImageApiProfile(settings)
       const profile = getTaskApiProfile(settings, latestTask)
-        ?? (latestTask.apiProfileId === normalizeSettings(settings).imageApiProfile.id ? normalizeSettings(settings).imageApiProfile : null)
+        ?? (latestTask.apiProfileId === imageProfile.id ? imageProfile : null)
       const usesApiProxy = profile?.apiProxy ?? settings.apiProxy
-      const imageProfile = normalizeSettings(settings).imageApiProfile
       const hintProfile = profile ?? {
         provider: latestTask.apiProvider ?? imageProfile.provider,
         apiMode: settings.apiMode,
@@ -4690,9 +4698,10 @@ export async function deleteFavoriteCollection(collectionId: string, deleteTasks
 export async function retryTask(task: TaskRecord) {
   const { settings } = useStore.getState()
   const normalizedSettings = normalizeSettings(settings)
-  const activeProfile = task.apiProfileId === normalizedSettings.imageApiProfile.id
-    ? normalizedSettings.imageApiProfile
-    : getTaskApiProfile(normalizedSettings, task) ?? normalizedSettings.imageApiProfile
+  const imageProfile = getImageApiProfile(normalizedSettings)
+  const activeProfile = task.apiProfileId === imageProfile.id
+    ? imageProfile
+    : getTaskApiProfile(normalizedSettings, task) ?? imageProfile
   const normalizedParams = normalizeParamsForSettings(task.params, settings, { hasInputImages: task.inputImageIds.length > 0 })
   const shouldUseTransparentOutput = normalizedParams.output_format === 'png' && normalizedParams.transparent_output
   const taskParams = shouldUseTransparentOutput
@@ -4735,10 +4744,10 @@ export async function retryTask(task: TaskRecord) {
 export async function reuseConfig(task: TaskRecord) {
   const { settings, setPrompt, setParams, setInputImages, setMaskDraft, clearMaskDraft, showToast, setConfirmDialog, setReusedTaskApiProfile } = useStore.getState()
   const normalizedSettings = normalizeSettings(settings)
-  const currentProfile = normalizedSettings.imageApiProfile
+  const currentProfile = getImageApiProfile(normalizedSettings)
   const matchedProfile = normalizedSettings.reuseTaskApiProfileTemporarily
-    ? (task.apiProfileId === normalizedSettings.imageApiProfile.id
-      ? normalizedSettings.imageApiProfile
+    ? (task.apiProfileId === currentProfile.id
+      ? currentProfile
       : getTaskApiProfile(normalizedSettings, task))
     : null
   const shouldTemporarilyReuseProfile = Boolean(matchedProfile && matchedProfile.id !== currentProfile.id)

--- a/src/store.ts
+++ b/src/store.ts
@@ -1821,6 +1821,9 @@ export function getTaskApiProfile(settings: AppSettings, task: TaskRecord): ApiP
 
 function createSettingsForApiProfile(settings: AppSettings, profile: ApiProfile): AppSettings {
   const normalized = normalizeSettings(settings)
+  const profiles = normalized.profiles.some((item) => item.id === profile.id)
+    ? normalized.profiles.map((item) => item.id === profile.id ? profile : item)
+    : [...normalized.profiles, profile]
   return normalizeSettings({
     ...normalized,
     baseUrl: profile.baseUrl,
@@ -1830,9 +1833,14 @@ function createSettingsForApiProfile(settings: AppSettings, profile: ApiProfile)
     apiMode: profile.apiMode,
     codexCli: profile.codexCli,
     apiProxy: profile.apiProxy,
-    profiles: normalized.profiles.map((item) => item.id === profile.id ? profile : item),
+    profiles,
     activeProfileId: profile.id,
   })
+}
+
+function createSettingsForAgentImageApiProfile(settings: AppSettings): AppSettings {
+  const normalized = normalizeSettings(settings)
+  return createSettingsForApiProfile(normalized, normalized.agentImageApiProfile)
 }
 
 function getReusedTaskApiProfile(settings: AppSettings, profileId: string | null): ApiProfile | null {
@@ -3102,6 +3110,16 @@ function countResponseToolCalls(output: ResponsesOutputItem[]) {
   return output.filter((item) => item.type === 'image_generation_call').length
 }
 
+function parseSingleImageCallArguments(args: string): { prompt: string } | null {
+  try {
+    const parsed = JSON.parse(args) as { prompt?: unknown }
+    const prompt = typeof parsed.prompt === 'string' ? parsed.prompt.trim() : ''
+    return prompt ? { prompt } : null
+  } catch {
+    return null
+  }
+}
+
 function createAgentContinuationInputItem(newImageRefs: string[], toolCallsUsed: number, maxToolCalls: number) {
   const lines = [
     '[System] The app has saved your generated outputs and is continuing the same Agent turn.',
@@ -3205,6 +3223,15 @@ export async function submitAgentMessage() {
     showToast(`请先完善请求 API 配置：${validateApiProfile(activeProfile)}`, 'error')
     state.setShowSettings(true)
     return
+  }
+
+  if (normalizedSettings.agentImageGenerationBackend === 'image-api') {
+    const imageProfileError = validateApiProfile(normalizedSettings.agentImageApiProfile)
+    if (imageProfileError) {
+      showToast(`请先完善 Agent 图像生成配置：${imageProfileError}`, 'error')
+      state.setShowSettings(true, 'agent')
+      return
+    }
   }
 
   const trimmedPrompt = prompt.trim()
@@ -3358,6 +3385,15 @@ export async function regenerateAgentAssistantMessage(conversationId: string, ro
     return
   }
 
+  if (normalizedSettings.agentImageGenerationBackend === 'image-api') {
+    const imageProfileError = validateApiProfile(normalizedSettings.agentImageApiProfile)
+    if (imageProfileError) {
+      showToast(`请先完善 Agent 图像生成配置：${imageProfileError}`, 'error')
+      state.setShowSettings(true, 'agent')
+      return
+    }
+  }
+
   const conversation = state.agentConversations.find((item) => item.id === conversationId)
   const sourceRound = conversation?.rounds.find((item) => item.id === roundId) ?? null
   const sourceUserMessage = sourceRound
@@ -3505,7 +3541,7 @@ async function executeAgentRound(
       toolCallId: string,
       taskPrompt = '',
       inputImageIds = round.inputImageIds ?? [],
-      options: { createdAt?: number; agentBatchCallId?: string; maskTargetImageId?: string | null; maskImageId?: string | null } = {},
+      options: { createdAt?: number; agentBatchCallId?: string; maskTargetImageId?: string | null; maskImageId?: string | null; profile?: ApiProfile } = {},
     ) => {
       const existingTaskId = taskIdByToolCallId.get(toolCallId)
       if (existingTaskId) return existingTaskId
@@ -3517,15 +3553,16 @@ async function executeAgentRound(
         return existingTask.id
       }
 
+      const taskProfile = options.profile ?? activeProfile
       const task: TaskRecord = {
         id: genId(),
         prompt: taskPrompt,
         params: { ...params, n: 1 },
-        apiProvider: activeProfile.provider,
-        apiProfileId: activeProfile.id,
-        apiProfileName: activeProfile.name,
-        apiMode: activeProfile.apiMode,
-        apiModel: activeProfile.model,
+        apiProvider: taskProfile.provider,
+        apiProfileId: taskProfile.id,
+        apiProfileName: taskProfile.name,
+        apiMode: taskProfile.apiMode,
+        apiModel: taskProfile.model,
         inputImageIds,
         maskTargetImageId: options.maskTargetImageId !== undefined ? options.maskTargetImageId : round.maskTargetImageId ?? null,
         maskImageId: options.maskImageId !== undefined ? options.maskImageId : round.maskImageId ?? null,
@@ -3622,6 +3659,9 @@ async function executeAgentRound(
     const maxToolCalls = Number.isFinite(requestSettings.agentMaxToolRounds)
       ? Math.max(1, Math.trunc(requestSettings.agentMaxToolRounds))
       : DEFAULT_AGENT_MAX_TOOL_ROUNDS
+    const useAgentImageApi = requestSettings.agentImageGenerationBackend === 'image-api'
+    const agentImageApiSettings = useAgentImageApi ? createSettingsForAgentImageApiProfile(requestSettings) : null
+    const agentImageApiProfile = agentImageApiSettings ? getActiveApiProfile(agentImageApiSettings) : null
     let apiInputForTurn = apiInput
     let accumulatedOutputItems: ResponsesOutputItem[] = []
     let accumulatedText = ''
@@ -3665,6 +3705,61 @@ async function executeAgentRound(
       return { dataUrls, imageIds }
     }
 
+    const executeImageApiCall = async (opts: {
+      toolCallId: string
+      prompt: string
+      references: { dataUrls: string[]; imageIds: string[] }
+      agentBatchCallId?: string
+      createdAt?: number
+    }): Promise<AgentApiResultImage> => {
+      if (!agentImageApiSettings || !agentImageApiProfile) {
+        throw new Error('Agent 图像生成配置不可用')
+      }
+
+      await ensureStreamingAgentTask(opts.toolCallId, opts.prompt, opts.references.imageIds, {
+        createdAt: opts.createdAt,
+        maskTargetImageId: null,
+        maskImageId: null,
+        profile: agentImageApiProfile,
+        ...(opts.agentBatchCallId ? { agentBatchCallId: opts.agentBatchCallId } : {}),
+      })
+
+      const result = await callImageApi({
+        settings: agentImageApiSettings,
+        prompt: replaceImageMentionsForApi(opts.prompt, opts.references.dataUrls.length),
+        params: {
+          ...normalizeParamsForSettings(params, agentImageApiSettings, { hasInputImages: opts.references.dataUrls.length > 0 }),
+          n: 1,
+        },
+        inputImageDataUrls: opts.references.dataUrls,
+        maskDataUrl: opts.references.imageIds.includes(round.maskTargetImageId ?? '') ? maskDataUrl : undefined,
+        onPartialImage: shouldStreamAssistantMessage
+          ? (partial) => {
+              const taskId = taskIdByToolCallId.get(opts.toolCallId)
+              if (taskId) {
+                useStore.getState().setTaskStreamPreview(taskId, partial.image, partial.partialImageIndex)
+                if (partial.partialImageIndex === 0 || partial.partialImageIndex == null) {
+                  void persistTaskStreamPartialImage(taskId, partial.image)
+                }
+              }
+            }
+          : undefined,
+      })
+
+      const image = result.images[0]
+      if (!image) {
+        throw new Error('接口未返回图片数据')
+      }
+
+      const agentImage: AgentApiResultImage = {
+        toolCallId: opts.toolCallId,
+        dataUrl: image,
+        actualParams: result.actualParamsList?.[0] ?? result.actualParams,
+        revisedPrompt: result.revisedPrompts?.[0] ?? opts.prompt,
+      }
+      return agentImage
+    }
+
     // Helper: execute a generate_image_batch function call concurrently
     const executeBatchFunctionCall = async (functionCallItem: ResponsesOutputItem): Promise<string> => {
       const callId = functionCallItem.call_id ?? ''
@@ -3681,17 +3776,42 @@ async function executeAgentRound(
         const referenceIds = uniqueIds(extractAgentReferenceIds(item.prompt))
         const references = await resolveReferenceImages(referenceIds)
         const batchToolCallId = genId()
-        await ensureStreamingAgentTask(batchToolCallId, item.prompt, references.imageIds, {
-          createdAt: Date.now(),
-          maskTargetImageId: null,
-          maskImageId: null,
-          ...(callId ? { agentBatchCallId: callId } : {}),
-        })
+        const createdAt = Date.now()
+        if (useAgentImageApi) {
+          await ensureStreamingAgentTask(batchToolCallId, item.prompt, references.imageIds, {
+            createdAt,
+            maskTargetImageId: null,
+            maskImageId: null,
+            profile: agentImageApiProfile ?? undefined,
+            ...(callId ? { agentBatchCallId: callId } : {}),
+          })
+        } else {
+          await ensureStreamingAgentTask(batchToolCallId, item.prompt, references.imageIds, {
+            createdAt,
+            maskTargetImageId: null,
+            maskImageId: null,
+            ...(callId ? { agentBatchCallId: callId } : {}),
+          })
+        }
         batchExecutionItems.push({ item, batchToolCallId, references, referenceIds })
       }
 
       // Fire all batch items concurrently after all cards are visible.
       const batchPromises = batchExecutionItems.map(async ({ item, batchToolCallId, references, referenceIds }) => {
+        if (useAgentImageApi) {
+          const image = await executeImageApiCall({
+            toolCallId: batchToolCallId,
+            prompt: item.prompt,
+            references,
+            agentBatchCallId: callId || undefined,
+          })
+          await completeAgentImageTask(image)
+          return {
+            batchItemId: item.id,
+            image: { ...image, dataUrl: image.dataUrl },
+            error: null,
+          }
+        }
 
         const batchResult = await callBatchImageSingle({
           profile: activeProfile,
@@ -3726,7 +3846,6 @@ async function executeAgentRound(
             : undefined,
         })
 
-        // If not streaming and we have an image, complete the pre-created task.
         if (batchResult.image && !shouldStreamAssistantMessage) {
           await completeAgentImageTask({ ...batchResult.image, toolCallId: batchToolCallId }, batchResult.rawResponsePayload)
         }
@@ -3766,6 +3885,30 @@ async function executeAgentRound(
       toolCallsUsed += successCount
 
       return JSON.stringify({ images: outputImages })
+    }
+
+    const executeSingleImageFunctionCall = async (functionCallItem: ResponsesOutputItem): Promise<string> => {
+      const parsed = parseSingleImageCallArguments(functionCallItem.arguments ?? '')
+      if (!parsed) return JSON.stringify({ error: 'Invalid or empty image arguments' })
+
+      const referenceIds = uniqueIds(extractAgentReferenceIds(parsed.prompt))
+      const references = await resolveReferenceImages(referenceIds)
+      const toolCallId = genId()
+      try {
+        const image = await executeImageApiCall({
+          toolCallId,
+          prompt: parsed.prompt,
+          references,
+          createdAt: Date.now(),
+        })
+        await completeAgentImageTask(image)
+        toolCallsUsed += 1
+        return JSON.stringify({ status: 'done' })
+      } catch (err) {
+        const error = err instanceof Error ? err.message : String(err)
+        failAgentImageTask(toolCallId, error, getRawErrorPayload(err).rawResponsePayload)
+        return JSON.stringify({ status: 'error', error })
+      }
     }
 
     while (true) {
@@ -3921,6 +4064,9 @@ async function executeAgentRound(
       const batchFunctionCalls = currentResponseOutputItems.filter(
         (item) => item.type === 'function_call' && item.name === 'generate_image_batch',
       )
+      const singleFunctionCalls = currentResponseOutputItems.filter(
+        (item) => item.type === 'function_call' && item.name === 'generate_image',
+      )
       const continueFunctionCalls = currentResponseOutputItems.filter(
         (item) => item.type === 'function_call' && item.name === 'continue_generation',
       )
@@ -3935,6 +4081,17 @@ async function executeAgentRound(
       if (batchFunctionCalls.length > 0) {
         for (const fc of batchFunctionCalls) {
           const output = await executeBatchFunctionCall(fc)
+          functionCallOutputs.push({
+            type: 'function_call_output',
+            call_id: fc.call_id,
+            output,
+          })
+        }
+      }
+
+      if (singleFunctionCalls.length > 0) {
+        for (const fc of singleFunctionCalls) {
+          const output = await executeSingleImageFunctionCall(fc)
           functionCallOutputs.push({
             type: 'function_call_output',
             call_id: fc.call_id,
@@ -3997,13 +4154,15 @@ async function executeAgentRound(
       pendingToolTextSeparator = true
     }
 
-    markAgentRoundTasksFailed(
-      conversationId,
-      roundId,
-      '内置 image_generation 工具未返回图片',
-      undefined,
-      (task) => Boolean(task.agentToolCallId && !task.agentBatchCallId),
-    )
+    if (!useAgentImageApi) {
+      markAgentRoundTasksFailed(
+        conversationId,
+        roundId,
+        '内置 image_generation 工具未返回图片',
+        undefined,
+        (task) => Boolean(task.agentToolCallId && !task.agentBatchCallId),
+      )
+    }
 
     const taskIds: string[] = [...streamingTaskIds]
     const outputIds = taskIds.flatMap((taskId) => useStore.getState().tasks.find((task) => task.id === taskId)?.outputImages ?? [])

--- a/src/store.ts
+++ b/src/store.ts
@@ -118,7 +118,7 @@ function isErrorToastTitle(title: string): boolean {
   return /(?:失败|错误|异常|报错|无法|不能|超时|中断|断开|请先|请输入|已达上限|不存在|已丢失)$/.test(title)
 }
 
-export type SettingsTab = 'general' | 'agent' | 'api' | 'data' | 'about'
+export type SettingsTab = 'general' | 'api' | 'data' | 'about'
 
 const TIMEOUT_STREAMING_HINT = '也可尝试打开「流式传输」，并提高「请求中间步骤图像数」来维持连接。'
 const TIMEOUT_PARTIAL_IMAGES_ZERO_HINT = '官方流式接口不发送心跳，当前「请求中间步骤图像数」为 0，连接可能因无数据传输而断开。建议提高到 2 或 3。'
@@ -3229,7 +3229,7 @@ export async function submitAgentMessage() {
     const imageProfileError = validateApiProfile(normalizedSettings.agentImageApiProfile)
     if (imageProfileError) {
       showToast(`请先完善 Agent 图像生成配置：${imageProfileError}`, 'error')
-      state.setShowSettings(true, 'agent')
+      state.setShowSettings(true, 'api')
       return
     }
   }
@@ -3389,7 +3389,7 @@ export async function regenerateAgentAssistantMessage(conversationId: string, ro
     const imageProfileError = validateApiProfile(normalizedSettings.agentImageApiProfile)
     if (imageProfileError) {
       showToast(`请先完善 Agent 图像生成配置：${imageProfileError}`, 'error')
-      state.setShowSettings(true, 'agent')
+      state.setShowSettings(true, 'api')
       return
     }
   }

--- a/src/store.ts
+++ b/src/store.ts
@@ -1675,7 +1675,7 @@ function putTask(task: TaskRecord): Promise<IDBValidKey> {
 }
 
 export function getCodexCliPromptKey(settings: AppSettings): string {
-  const profile = getActiveApiProfile(settings)
+  const profile = normalizeSettings(settings).imageApiProfile
   return `${profile.baseUrl}\n${profile.apiKey}`
 }
 
@@ -1838,9 +1838,9 @@ function createSettingsForApiProfile(settings: AppSettings, profile: ApiProfile)
   })
 }
 
-function createSettingsForAgentImageApiProfile(settings: AppSettings): AppSettings {
+function createSettingsForImageApiProfile(settings: AppSettings): AppSettings {
   const normalized = normalizeSettings(settings)
-  return createSettingsForApiProfile(normalized, normalized.agentImageApiProfile)
+  return createSettingsForApiProfile(normalized, normalized.imageApiProfile)
 }
 
 function getReusedTaskApiProfile(settings: AppSettings, profileId: string | null): ApiProfile | null {
@@ -2296,17 +2296,19 @@ export async function submitTask(options: { allowFullMask?: boolean; useCurrentA
     useStore.getState()
 
   const normalizedSettings = normalizeSettings(settings)
-  let activeProfile = getActiveApiProfile(settings)
+  let activeProfile: ApiProfile = normalizedSettings.imageApiProfile
   let requestSettings = createSettingsForApiProfile(normalizedSettings, activeProfile)
   if (normalizedSettings.reuseTaskApiProfileTemporarily && (reusedTaskApiProfileId || reusedTaskApiProfileMissing)) {
-    const reusedProfile = getReusedTaskApiProfile(normalizedSettings, reusedTaskApiProfileId)
+    const reusedProfile = reusedTaskApiProfileId === normalizedSettings.imageApiProfile.id
+      ? normalizedSettings.imageApiProfile
+      : getReusedTaskApiProfile(normalizedSettings, reusedTaskApiProfileId)
     if (!reusedProfile) {
       if (options.useCurrentApiProfileWhenReusedMissing) {
         useStore.getState().setReusedTaskApiProfile(null)
       } else {
         setConfirmDialog({
           title: '找不到 API 配置',
-      message: `找不到复用任务所使用的 API 配置「${reusedTaskApiProfileName || '未知配置'}」，要使用当前的 API 配置「${activeProfile.name}」提交任务吗？`,
+      message: `找不到复用任务所使用的 API 配置「${reusedTaskApiProfileName || '未知配置'}」，要使用当前的图像生成配置「${activeProfile.name}」提交任务吗？`,
       confirmText: '使用当前配置提交',
       cancelText: '放弃提交',
       action: () => {
@@ -3226,9 +3228,9 @@ export async function submitAgentMessage() {
   }
 
   if (normalizedSettings.agentImageGenerationBackend === 'image-api') {
-    const imageProfileError = validateApiProfile(normalizedSettings.agentImageApiProfile)
+    const imageProfileError = validateApiProfile(normalizedSettings.imageApiProfile)
     if (imageProfileError) {
-      showToast(`请先完善 Agent 图像生成配置：${imageProfileError}`, 'error')
+      showToast(`请先完善图像生成配置：${imageProfileError}`, 'error')
       state.setShowSettings(true, 'api')
       return
     }
@@ -3386,9 +3388,9 @@ export async function regenerateAgentAssistantMessage(conversationId: string, ro
   }
 
   if (normalizedSettings.agentImageGenerationBackend === 'image-api') {
-    const imageProfileError = validateApiProfile(normalizedSettings.agentImageApiProfile)
+    const imageProfileError = validateApiProfile(normalizedSettings.imageApiProfile)
     if (imageProfileError) {
-      showToast(`请先完善 Agent 图像生成配置：${imageProfileError}`, 'error')
+      showToast(`请先完善图像生成配置：${imageProfileError}`, 'error')
       state.setShowSettings(true, 'api')
       return
     }
@@ -3660,8 +3662,8 @@ async function executeAgentRound(
       ? Math.max(1, Math.trunc(requestSettings.agentMaxToolRounds))
       : DEFAULT_AGENT_MAX_TOOL_ROUNDS
     const useAgentImageApi = requestSettings.agentImageGenerationBackend === 'image-api'
-    const agentImageApiSettings = useAgentImageApi ? createSettingsForAgentImageApiProfile(requestSettings) : null
-    const agentImageApiProfile = agentImageApiSettings ? getActiveApiProfile(agentImageApiSettings) : null
+    const imageApiSettings = useAgentImageApi ? createSettingsForImageApiProfile(requestSettings) : null
+    const imageApiProfile = imageApiSettings ? getActiveApiProfile(imageApiSettings) : null
     let apiInputForTurn = apiInput
     let accumulatedOutputItems: ResponsesOutputItem[] = []
     let accumulatedText = ''
@@ -3712,23 +3714,23 @@ async function executeAgentRound(
       agentBatchCallId?: string
       createdAt?: number
     }): Promise<AgentApiResultImage> => {
-      if (!agentImageApiSettings || !agentImageApiProfile) {
-        throw new Error('Agent 图像生成配置不可用')
+      if (!imageApiSettings || !imageApiProfile) {
+        throw new Error('图像生成配置不可用')
       }
 
       await ensureStreamingAgentTask(opts.toolCallId, opts.prompt, opts.references.imageIds, {
         createdAt: opts.createdAt,
         maskTargetImageId: null,
         maskImageId: null,
-        profile: agentImageApiProfile,
+        profile: imageApiProfile,
         ...(opts.agentBatchCallId ? { agentBatchCallId: opts.agentBatchCallId } : {}),
       })
 
       const result = await callImageApi({
-        settings: agentImageApiSettings,
+        settings: imageApiSettings,
         prompt: replaceImageMentionsForApi(opts.prompt, opts.references.dataUrls.length),
         params: {
-          ...normalizeParamsForSettings(params, agentImageApiSettings, { hasInputImages: opts.references.dataUrls.length > 0 }),
+          ...normalizeParamsForSettings(params, imageApiSettings, { hasInputImages: opts.references.dataUrls.length > 0 }),
           n: 1,
         },
         inputImageDataUrls: opts.references.dataUrls,
@@ -3782,7 +3784,7 @@ async function executeAgentRound(
             createdAt,
             maskTargetImageId: null,
             maskImageId: null,
-            profile: agentImageApiProfile ?? undefined,
+            profile: imageApiProfile ?? undefined,
             ...(callId ? { agentBatchCallId: callId } : {}),
           })
         } else {
@@ -4275,6 +4277,7 @@ async function executeTask(taskId: string) {
   const task = useStore.getState().tasks.find((t) => t.id === taskId)
   if (!task) return
   const taskProfile = getTaskApiProfile(settings, task)
+    ?? (task.apiProfileId === normalizeSettings(settings).imageApiProfile.id ? normalizeSettings(settings).imageApiProfile : null)
   if (!taskProfile && task.apiProfileId) {
     updateTaskInStore(taskId, {
       status: 'error',
@@ -4286,7 +4289,7 @@ async function executeTask(taskId: string) {
     })
     return
   }
-  const activeProfile = taskProfile ?? getActiveApiProfile(settings)
+  const activeProfile = taskProfile ?? normalizeSettings(settings).imageApiProfile
   const requestSettings = createSettingsForApiProfile(settings, activeProfile)
   const taskProvider = task.apiProvider ?? activeProfile.provider
   let falRequestInfo: { requestId: string; endpoint: string } | null = task.falRequestId && task.falEndpoint
@@ -4467,13 +4470,14 @@ async function executeTask(taskId: string) {
       let errorMessage = err instanceof Error ? err.message : String(err)
       const settings = useStore.getState().settings
       const profile = getTaskApiProfile(settings, latestTask)
+        ?? (latestTask.apiProfileId === normalizeSettings(settings).imageApiProfile.id ? normalizeSettings(settings).imageApiProfile : null)
       const usesApiProxy = profile?.apiProxy ?? settings.apiProxy
-      const activeProfile = getActiveApiProfile(settings)
+      const imageProfile = normalizeSettings(settings).imageApiProfile
       const hintProfile = profile ?? {
-        provider: latestTask.apiProvider ?? activeProfile.provider,
+        provider: latestTask.apiProvider ?? imageProfile.provider,
         apiMode: settings.apiMode,
-        streamImages: activeProfile.streamImages,
-        streamPartialImages: activeProfile.streamPartialImages,
+        streamImages: imageProfile.streamImages,
+        streamPartialImages: imageProfile.streamPartialImages,
       }
       const networkErrorHint = getApiRequestNetworkErrorHint(err, latestTask.createdAt, usesApiProxy, hintProfile)
       if (networkErrorHint && !errorMessage.includes(IMAGE_FETCH_CORS_HINT)) {
@@ -4685,7 +4689,10 @@ export async function deleteFavoriteCollection(collectionId: string, deleteTasks
 /** 重试失败的任务：创建新任务并执行 */
 export async function retryTask(task: TaskRecord) {
   const { settings } = useStore.getState()
-  const activeProfile = getActiveApiProfile(settings)
+  const normalizedSettings = normalizeSettings(settings)
+  const activeProfile = task.apiProfileId === normalizedSettings.imageApiProfile.id
+    ? normalizedSettings.imageApiProfile
+    : getTaskApiProfile(normalizedSettings, task) ?? normalizedSettings.imageApiProfile
   const normalizedParams = normalizeParamsForSettings(task.params, settings, { hasInputImages: task.inputImageIds.length > 0 })
   const shouldUseTransparentOutput = normalizedParams.output_format === 'png' && normalizedParams.transparent_output
   const taskParams = shouldUseTransparentOutput
@@ -4728,8 +4735,12 @@ export async function retryTask(task: TaskRecord) {
 export async function reuseConfig(task: TaskRecord) {
   const { settings, setPrompt, setParams, setInputImages, setMaskDraft, clearMaskDraft, showToast, setConfirmDialog, setReusedTaskApiProfile } = useStore.getState()
   const normalizedSettings = normalizeSettings(settings)
-  const currentProfile = getActiveApiProfile(settings)
-  const matchedProfile = normalizedSettings.reuseTaskApiProfileTemporarily ? getTaskApiProfile(normalizedSettings, task) : null
+  const currentProfile = normalizedSettings.imageApiProfile
+  const matchedProfile = normalizedSettings.reuseTaskApiProfileTemporarily
+    ? (task.apiProfileId === normalizedSettings.imageApiProfile.id
+      ? normalizedSettings.imageApiProfile
+      : getTaskApiProfile(normalizedSettings, task))
+    : null
   const shouldTemporarilyReuseProfile = Boolean(matchedProfile && matchedProfile.id !== currentProfile.id)
   const missingReusedProfile = normalizedSettings.reuseTaskApiProfileTemporarily && !matchedProfile
   const taskProfileName = matchedProfile?.name ?? getTaskApiProfileName(task)
@@ -4771,7 +4782,7 @@ export async function reuseConfig(task: TaskRecord) {
   if (missingReusedProfile) {
     setConfirmDialog({
       title: '找不到 API 配置',
-      message: `找不到复用任务所使用的 API 配置「${taskProfileName}」，要使用当前的 API 配置「${currentProfile.name}」提交任务吗？`,
+      message: `找不到复用任务所使用的 API 配置「${taskProfileName}」，要使用当前的图像生成配置「${currentProfile.name}」提交任务吗？`,
       confirmText: '使用当前配置提交',
       cancelText: '放弃提交',
       action: () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -110,7 +110,7 @@ export interface AppSettings {
   agentWebSearch: boolean
   agentMathFormattingPrompt: boolean
   agentImageGenerationBackend: AgentImageGenerationBackend
-  agentImageApiProfile: ApiProfile
+  imageApiProfile: ApiProfile
   profiles: ApiProfile[]
   activeProfileId: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,6 +82,8 @@ export interface ApiProfile {
   streamImages?: boolean
   streamPartialImages?: number
   providerDrafts?: Partial<Record<ApiProvider, Partial<Pick<ApiProfile, 'baseUrl' | 'model' | 'apiMode' | 'codexCli' | 'apiProxy' | 'responseFormatB64Json' | 'streamImages' | 'streamPartialImages'>>>>
+  agentImageGenerationBackend: AgentImageGenerationBackend
+  imageApiProfile?: ApiProfile
 }
 
 export interface AppSettings {
@@ -109,8 +111,6 @@ export interface AppSettings {
   agentMaxToolRounds: number
   agentWebSearch: boolean
   agentMathFormattingPrompt: boolean
-  agentImageGenerationBackend: AgentImageGenerationBackend
-  imageApiProfile: ApiProfile
   profiles: ApiProfile[]
   activeProfileId: string
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,7 @@
 
 export type ApiMode = 'images' | 'responses'
 export type AppMode = 'gallery' | 'agent'
+export type AgentImageGenerationBackend = 'native' | 'image-api'
 export type ReferenceImageEditAction = 'ask' | 'replace-reference' | 'add-mask'
 export const ZIP_DOWNLOAD_ROUTE_VALUES = [
   'task-selection',
@@ -108,6 +109,8 @@ export interface AppSettings {
   agentMaxToolRounds: number
   agentWebSearch: boolean
   agentMathFormattingPrompt: boolean
+  agentImageGenerationBackend: AgentImageGenerationBackend
+  agentImageApiProfile: ApiProfile
   profiles: ApiProfile[]
   activeProfileId: string
 }


### PR DESCRIPTION
本pr分离了Agent对话配置与图像生成配置，可以单独配置图像生成使用独立的api配置（可选 `沿用Agent对话配置` 使用responses api调用gpt模型的内置图像生成工具，或`独立Images API` 调用image-2模型生成）。本pr旨在解决有些供应商的gpt模型不支持内置的图像生成工具的情况，提供了自定义的图像生成tool供模型调用。

```text
AppSettings
├── profiles: ApiProfile[]
│   ├── id, name
│   ├── provider, baseUrl, apiKey, model, timeout  ← Agent 对话 API 配置
│   ├── apiMode: 'images' | 'responses'
│   ├── streamImages, streamPartialImages
│   ├── agentImageGenerationBackend: 'native' | 'no_image'
│   └── imageApiProfile: {          ← 图像生成 API 配置
│         id, name
│         provider, baseUrl, apiKey, model, timeout
│         apiMode: 'images'（固定）
│       }
```

后续方向：
1. agent对话支持completion接口
2. 重构profile结构和url导入参数