### PR TITLE
feat: 新增批量生图模式

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -388,6 +388,8 @@ export default function InputBar() {
   const prompt = useStore((s) => s.prompt)
   const appMode = useStore((s) => s.appMode)
   const setPrompt = useStore((s) => s.setPrompt)
+  const batchMode = useStore((s) => s.batchMode)
+  const setBatchMode = useStore((s) => s.setBatchMode)
   const inputImages = useStore((s) => s.inputImages)
   const addInputImage = useStore((s) => s.addInputImage)
   const replaceInputImage = useStore((s) => s.replaceInputImage)
@@ -624,6 +626,7 @@ export default function InputBar() {
   const [isSingleLine, setIsSingleLine] = useState(true)
   const [submitHover, setSubmitHover] = useState(false)
   const [attachHover, setAttachHover] = useState(false)
+  const [batchHover, setBatchHover] = useState(false)
   const [imageHintId, setImageHintId] = useState<string | null>(null)
   const [mobileCollapsed, setMobileCollapsed] = useState(false)
   const [showSizePicker, setShowSizePicker] = useState(false)
@@ -718,7 +721,9 @@ export default function InputBar() {
     ? maskDraft ? '遮罩编辑' : '生成图像'
     : '请先配置 API'
   const submitTooltipText = activeAgentIsRunning ? '停止生成' : '尚未完成 API 配置，请在右上角设置中进行'
-  const promptPlaceholder = '描述你想生成的图片，可输入 @ 来指定参考图...'
+  const promptPlaceholder = batchMode
+    ? '批量模式：每行一个提示词，将分别生成...'
+    : '描述你想生成的图片，可输入 @ 来指定参考图...'
   const submitCurrentMode = useCallback(() => {
     if (appMode === 'agent') {
       void submitAgentMessage()
@@ -2101,6 +2106,28 @@ export default function InputBar() {
               {renderParams('grid-cols-6')}
 
               <div className="flex gap-2 flex-shrink-0 mb-0.5">
+                {appMode === 'gallery' && (
+                  <div
+                    className="relative"
+                    onMouseEnter={() => setBatchHover(true)}
+                    onMouseLeave={() => setBatchHover(false)}
+                  >
+                    <ButtonTooltip visible={batchHover} text={batchMode ? '关闭批量模式' : '开启批量模式（每行一个提示词）'} />
+                    <button
+                      onClick={() => setBatchMode(!batchMode)}
+                      className={`p-2.5 rounded-xl transition-all shadow-sm ${
+                        batchMode
+                          ? 'bg-blue-500 text-white hover:bg-blue-600'
+                          : 'bg-gray-200 dark:bg-white/[0.06] hover:bg-gray-300 dark:hover:bg-white/[0.1] text-gray-500 dark:text-gray-300 hover:shadow'
+                      }`}
+                      aria-label={batchMode ? '关闭批量模式' : '开启批量模式'}
+                    >
+                      <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                      </svg>
+                    </button>
+                  </div>
+                )}
                 <div
                   className="relative"
                   onMouseEnter={() => setAttachHover(true)}

--- a/src/store.ts
+++ b/src/store.ts
@@ -796,6 +796,8 @@ interface AppState {
   // 输入
   prompt: string
   setPrompt: (p: string) => void
+  batchMode: boolean
+  setBatchMode: (v: boolean) => void
   inputImages: InputImage[]
   addInputImage: (img: InputImage) => void
   replaceInputImage: (idx: number, img: InputImage) => void
@@ -1278,6 +1280,8 @@ export const useStore = create<AppState>()(
       // Input
       prompt: '',
       setPrompt: (prompt) => set((s) => syncActiveInputDraft(s, { prompt })),
+      batchMode: false,
+      setBatchMode: (batchMode) => set({ batchMode }),
       inputImages: [],
       addInputImage: (img) =>
         set((s) => {
@@ -2331,7 +2335,7 @@ export async function initStore() {
 
 /** 提交新任务 */
 export async function submitTask(options: { allowFullMask?: boolean; useCurrentApiProfileWhenReusedMissing?: boolean } = {}) {
-  const { settings, prompt, inputImages, maskDraft, params, reusedTaskApiProfileId, reusedTaskApiProfileName, reusedTaskApiProfileMissing, showToast, setConfirmDialog } =
+  const { settings, prompt, inputImages, maskDraft, params, batchMode, reusedTaskApiProfileId, reusedTaskApiProfileName, reusedTaskApiProfileMissing, showToast, setConfirmDialog } =
     useStore.getState()
 
   const normalizedSettings = normalizeSettings(settings)
@@ -2371,6 +2375,11 @@ export async function submitTask(options: { allowFullMask?: boolean; useCurrentA
     return
   }
 
+  // 批量模式：按行拆分提示词
+  const promptLines = batchMode
+    ? prompt.split('\n').map(line => line.trim()).filter(line => line.length > 0)
+    : [prompt.trim()]
+
   let orderedInputImages = inputImages
   let maskImageId: string | null = null
   let maskTargetImageId: string | null = null
@@ -2408,46 +2417,62 @@ export async function submitTask(options: { allowFullMask?: boolean; useCurrentA
     await storeImage(img.dataUrl)
   }
 
-  const normalizedParams = normalizeParamsForSettings(params, requestSettings, { hasInputImages: orderedInputImages.length > 0 })
-  const shouldUseTransparentOutput = normalizedParams.output_format === 'png' && normalizedParams.transparent_output
-  const taskParams = shouldUseTransparentOutput
-    ? getTransparentRequestParams(normalizedParams)
-    : { ...normalizedParams, transparent_output: false }
-  const transparentMeta = taskParams.transparent_output
-    ? createTransparentOutputMeta(prompt.trim())
-    : null
-  const normalizedParamPatch = getChangedParams(params, taskParams)
+  // 构建任务的 helper 函数
+  const buildTaskFor = (promptText: string): TaskRecord => {
+    const normalizedParams = normalizeParamsForSettings(params, requestSettings, { hasInputImages: orderedInputImages.length > 0 })
+    const shouldUseTransparentOutput = normalizedParams.output_format === 'png' && normalizedParams.transparent_output
+    const taskParams = shouldUseTransparentOutput
+      ? getTransparentRequestParams(normalizedParams)
+      : { ...normalizedParams, transparent_output: false }
+    const transparentMeta = taskParams.transparent_output
+      ? createTransparentOutputMeta(promptText)
+      : null
+
+    const taskId = genId()
+    return {
+      id: taskId,
+      prompt: promptText,
+      params: taskParams,
+      apiProvider: activeProfile.provider,
+      apiProfileId: activeProfile.id,
+      apiProfileName: activeProfile.name,
+      apiMode: activeProfile.apiMode,
+      apiModel: activeProfile.model,
+      inputImageIds: orderedInputImages.map((i) => i.id),
+      maskTargetImageId,
+      maskImageId,
+      transparentOutput: transparentMeta?.transparentOutput,
+      transparentPrompt: transparentMeta?.effectivePrompt,
+      outputImages: [],
+      status: 'running',
+      error: null,
+      createdAt: Date.now(),
+      finishedAt: null,
+      elapsed: null,
+    }
+  }
+
+  // 为所有提示词创建任务
+  const newTasks = promptLines.map(promptText => buildTaskFor(promptText))
+
+  // 归一化参数并同步到 store（仅从第一个任务提取）
+  const normalizedParamPatch = getChangedParams(params, newTasks[0].params)
   if (Object.keys(normalizedParamPatch).length) {
     useStore.getState().setParams(normalizedParamPatch)
   }
 
-  const taskId = genId()
-  const task: TaskRecord = {
-    id: taskId,
-    prompt: prompt.trim(),
-    params: taskParams,
-    apiProvider: activeProfile.provider,
-    apiProfileId: activeProfile.id,
-    apiProfileName: activeProfile.name,
-    apiMode: activeProfile.apiMode,
-    apiModel: activeProfile.model,
-    inputImageIds: orderedInputImages.map((i) => i.id),
-    maskTargetImageId,
-    maskImageId,
-    transparentOutput: transparentMeta?.transparentOutput,
-    transparentPrompt: transparentMeta?.effectivePrompt,
-    outputImages: [],
-    status: 'running',
-    error: null,
-    createdAt: Date.now(),
-    finishedAt: null,
-    elapsed: null,
+  const latestTasks = useStore.getState().tasks
+  useStore.getState().setTasks([...newTasks, ...latestTasks])
+
+  // 持久化所有任务
+  for (const task of newTasks) {
+    await putTask(task)
   }
 
-  const latestTasks = useStore.getState().tasks
-  useStore.getState().setTasks([task, ...latestTasks])
-  await putTask(task)
-  useStore.getState().showToast('任务已提交', 'success')
+  useStore.getState().showToast(
+    newTasks.length === 1 ? '任务已提交' : `已提交 ${newTasks.length} 个任务`,
+    'success'
+  )
 
   if (settings.clearInputAfterSubmit) {
     useStore.getState().setPrompt('')
@@ -2455,8 +2480,10 @@ export async function submitTask(options: { allowFullMask?: boolean; useCurrentA
   }
   useStore.getState().setReusedTaskApiProfile(null)
 
-  // 异步调用 API
-  executeTask(taskId)
+  // 并发执行所有任务
+  for (const task of newTasks) {
+    executeTask(task.id)
+  }
 }
 
 function getActiveAgentConversation(): AgentConversation {


### PR DESCRIPTION
点击批量生图按钮，每行输入一个提示词作为单独的提示词批量进行生图。已经通过233个测试。

<img width="482" height="79" alt="image" src="https://github.com/user-attachments/assets/9be353ac-342d-4a33-9df3-266863e17ac0" />

<img width="958" height="266" alt="image" src="https://github.com/user-attachments/assets/54f7d233-f70d-4657-8279-133a2eda3943" />

不过由于我这边没有/v1/images的生图API，只有/v1/chat/completions的生图API 所以可以看到并行创建生图任务

<img width="1447" height="904" alt="image" src="https://github.com/user-attachments/assets/7b13134d-71b6-4adc-bbfc-3eb6d01ae772" />

## 提到的issues:
https://github.com/CookSleep/gpt_image_playground/issues/98