### PR TITLE
fix: resolve >2GB export failure and improve error handling

### DIFF
--- a/src/lib/exportZip.ts
+++ b/src/lib/exportZip.ts
@@ -6,6 +6,9 @@ import { getNumberedFileNameBase, sanitizeFileNamePart } from './exportFileName'
 
 type ZipFiles = Record<string, Uint8Array | [Uint8Array, { mtime: Date }]>
 
+const MAX_EXPORT_BLOB_BYTES = 2_147_483_647
+const EXPORT_BLOB_CHUNK_BYTES = 512 * 1024 * 1024
+
 export interface BuildExportZipOptions {
   exportConfig?: boolean
   exportTasks?: boolean
@@ -26,6 +29,12 @@ export interface BuildExportZipParams {
 export interface ExportZipContents {
   manifest: ExportData
   files: Record<string, Uint8Array>
+}
+
+export interface ExportZipPart {
+  fileName: string
+  manifest: ExportData
+  bytes: Uint8Array
 }
 
 export function buildExportZip(params: BuildExportZipParams) {
@@ -89,6 +98,86 @@ export function buildExportZip(params: BuildExportZipParams) {
   return {
     manifest,
     bytes: zipSync(zipFiles, { level: 6 }),
+  }
+}
+
+export function getExportBlobLimitError(byteLength: number): string | null {
+  if (byteLength > MAX_EXPORT_BLOB_BYTES) {
+    return '当前备份文件超过浏览器支持的 2 GB 下载限制，请减少导出的图片或分批导出。'
+  }
+  return null
+}
+
+export function createExportBlob(bytes: Uint8Array): Blob {
+  const limitError = getExportBlobLimitError(bytes.byteLength)
+  if (limitError) throw new Error(limitError)
+
+  if (bytes.byteLength <= EXPORT_BLOB_CHUNK_BYTES) {
+    return new Blob([bytes], { type: 'application/zip' })
+  }
+
+  const parts: BlobPart[] = []
+  for (let offset = 0; offset < bytes.byteLength; offset += EXPORT_BLOB_CHUNK_BYTES) {
+    const chunk = bytes.subarray(offset, Math.min(offset + EXPORT_BLOB_CHUNK_BYTES, bytes.byteLength))
+    parts.push(chunk)
+  }
+
+  return new Blob(parts, { type: 'application/zip' })
+}
+
+export function buildExportZipParts(params: BuildExportZipParams, options: { maxBytes?: number } = {}) {
+  const maxBytes = options.maxBytes ?? MAX_EXPORT_BLOB_BYTES
+  if (!params.options.exportTasks || !params.tasks.length) {
+    const result = buildExportZip(params)
+    return [{ fileName: 'gpt-image-playground-backup.zip', manifest: result.manifest, bytes: result.bytes }]
+  }
+
+  const parts = splitExportZipTasks(params, maxBytes)
+  return parts.map((part, index) => ({
+    fileName: parts.length > 1 ? `gpt-image-playground-backup_part${String(index + 1).padStart(2, '0')}.zip` : 'gpt-image-playground-backup.zip',
+    manifest: part.manifest,
+    bytes: part.bytes,
+  }))
+}
+
+function splitExportZipTasks(params: BuildExportZipParams, maxBytes: number, tasks = params.tasks): ExportZipPart[] {
+  if (!tasks.length) return []
+  const taskImageIds = new Set<string>()
+  for (const task of tasks) addTaskReferencedImageIds(taskImageIds, task)
+  const images = params.images.filter((image) => taskImageIds.has(image.id))
+  const thumbnailsByImageId = new Map<string, NonNullable<Awaited<ReturnType<typeof getImageThumbnail>>>>()
+  for (const image of images) {
+    const thumbnail = params.thumbnailsByImageId.get(image.id)
+    if (thumbnail?.thumbnailDataUrl) thumbnailsByImageId.set(image.id, thumbnail)
+  }
+  const result = buildExportZip({
+    ...params,
+    tasks,
+    images,
+    thumbnailsByImageId,
+  })
+  if (result.bytes.byteLength <= maxBytes) {
+    return [{ fileName: '', manifest: result.manifest, bytes: result.bytes }]
+  }
+  if (tasks.length === 1) {
+    throw new Error('单个任务资源过大，无法继续拆分为更小的备份分包。请减少该任务中的图片后再试。')
+  }
+  const midpoint = Math.floor(tasks.length / 2)
+  return [
+    ...splitExportZipTasks(params, maxBytes, tasks.slice(0, midpoint)),
+    ...splitExportZipTasks(params, maxBytes, tasks.slice(midpoint)),
+  ]
+}
+
+function addTaskReferencedImageIds(taskImageIds: Set<string>, task: TaskRecord) {
+  for (const imageId of [
+    ...(task.inputImageIds || []),
+    ...(task.maskImageId ? [task.maskImageId] : []),
+    ...(task.outputImages || []),
+    ...(task.transparentOriginalImages || []),
+    ...(task.streamPartialImageIds || []),
+  ]) {
+    if (imageId) taskImageIds.add(imageId)
   }
 }
 

--- a/src/store.test.ts
+++ b/src/store.test.ts
@@ -130,6 +130,7 @@ vi.mock('./lib/agentApi', () => ({
 import { clearAgentConversations, clearImages, clearTasks, getAllAgentConversations, getAllTasks, getImage, putAgentConversation, putImage, putTask as putDbTask } from './lib/db'
 import { callAgentResponsesApi, callBatchImageSingle } from './lib/agentApi'
 import { getFalQueuedImageResult } from './lib/falAiImageApi'
+import { getExportBlobLimitError } from './lib/exportZip'
 import { removeKeyedBackgroundFromDataUrl } from './lib/transparentImage'
 import { cleanStaleAgentInputDrafts, clearFailedTasks, deleteAgentRoundFromConversation, deleteFavoriteCollection, editOutputs, getActiveAgentRounds, getAgentConversationTaskIds, getAgentRoundTaskIds, getErrorToastMessage, getPersistedState, getTaskApiProfile, importData, initStore, markInterruptedOpenAIRunningTasks, migratePersistedState, regenerateAgentAssistantMessage, remapAgentRoundMentionsForPathChange, removeTask, reuseConfig, stopAgentResponse, submitAgentMessage, submitTask, taskMatchesFilterStatus, taskMatchesSearchQuery, useStore } from './store'
 
@@ -143,6 +144,15 @@ describe('error toast messages', () => {
 
   it('uses a generic message for long raw errors without a title', () => {
     expect(getErrorToastMessage(`invalid request ${'x'.repeat(90)}`)).toBe('操作失败，请查看详情')
+  })
+
+  it('preserves generic failure details for export failures', () => {
+    expect(getErrorToastMessage('导出失败：ZIP 文件生成失败')).toBe('导出失败：ZIP 文件生成失败')
+  })
+
+  it('detects export blobs that exceed the browser size limit', () => {
+    expect(getExportBlobLimitError(2_147_483_647)).toBeNull()
+    expect(getExportBlobLimitError(2_147_483_648)).toContain('2 GB')
   })
 })
 

--- a/src/store.ts
+++ b/src/store.ts
@@ -54,7 +54,7 @@ import { getChangedParams, normalizeParamsForSettings } from './lib/paramCompati
 import { createTransparentOutputMeta, getTransparentRequestParams, removeKeyedBackgroundFromDataUrl } from './lib/transparentImage'
 import { blobToDataUrl, fileToDataUrl } from './lib/dataUrl'
 import { formatExportFileTime } from './lib/exportFileName'
-import { buildExportZip, readExportZip, readExportZipFileAsDataUrl } from './lib/exportZip'
+import { buildExportZipParts, createExportBlob, readExportZip, readExportZipFileAsDataUrl } from './lib/exportZip'
 
 export const ALL_FAVORITES_COLLECTION_ID = '__all_favorites__'
 export const DEFAULT_FAVORITE_COLLECTION_ID = '__default_favorites__'
@@ -106,7 +106,10 @@ export function getErrorToastMessage(message: string): string {
   const separatorIndex = firstLine.search(/[：:]/)
   if (separatorIndex > 0) {
     const title = firstLine.slice(0, separatorIndex).trim()
-    if (isErrorToastTitle(title)) return title
+    const detail = firstLine.slice(separatorIndex + 1).trim()
+    const preserveDetailForGenericFailure = /^(?:导出|导入|保存|清空|创建|更新|加载).*失败$/.test(title)
+    if (isErrorToastTitle(title) && !preserveDetailForGenericFailure) return title
+    if (isErrorToastTitle(title) && preserveDetailForGenericFailure && detail) return firstLine
   }
 
   if (firstLine.length > ERROR_TOAST_MAX_LENGTH) return '操作失败，请查看详情'
@@ -1607,9 +1610,10 @@ export const useStore = create<AppState>()(
         const toastMessage = getToastMessage(message, type)
         const toast = { message: toastMessage, type }
         set({ toast })
+        const duration = type === 'error' ? 8000 : 3000
         setTimeout(() => {
           set((s) => (s.toast === toast ? { toast: null } : s))
-        }, 3000)
+        }, duration)
       },
 
       // Confirm
@@ -5432,7 +5436,7 @@ export async function exportData(options: ExportOptions = { exportConfig: true, 
       }
     }
 
-    const { bytes: zipped } = buildExportZip({
+    const exportParts = buildExportZipParts({
       options,
       exportedAt,
       settings,
@@ -5443,21 +5447,26 @@ export async function exportData(options: ExportOptions = { exportConfig: true, 
       defaultFavoriteCollectionId,
       agentConversations: getPersistableAgentConversations(agentConversations),
     })
-    const blob = new Blob([zipped.buffer as ArrayBuffer], { type: 'application/zip' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `gpt-image-playground-backup_${formatExportFileTime(new Date(exportedAt))}.zip`
-    a.click()
-    URL.revokeObjectURL(url)
-    useStore.getState().showToast('数据已导出', 'success')
+    for (const [index, part] of exportParts.entries()) {
+      const blob = createExportBlob(part.bytes)
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${part.fileName || `gpt-image-playground-backup_${formatExportFileTime(new Date(exportedAt))}.zip`}`
+      document.body.appendChild(a)
+      a.click()
+      a.remove()
+      URL.revokeObjectURL(url)
+      if (index < exportParts.length - 1) {
+        await new Promise((resolve) => setTimeout(resolve, 100))
+      }
+    }
+    useStore.getState().showToast(exportParts.length > 1 ? `已分 ${exportParts.length} 批导出` : '数据已导出', 'success')
   } catch (e) {
-    useStore
-      .getState()
-      .showToast(
-        `导出失败：${e instanceof Error ? e.message : String(e)}`,
-        'error',
-      )
+    console.error('exportData failed', e)
+    const errorMessage = e instanceof Error ? e.message.trim() : String(e).trim()
+    const message = errorMessage ? `导出失败：${errorMessage}` : '导出失败：未知错误'
+    useStore.getState().showToast(message, 'error')
   }
 }
 


### PR DESCRIPTION
- fix: split large buffers to bypass the browser 2GB limit for zip export
- refactor: slightly extend error popup duration for better readability
- refactor: log detailed error messages to the console for debugging

Firefox下导出数据超过2GB 会报错:
```
exportData failed TypeError: Blob constructor: ArrayBuffer branch of ((ArrayBufferView or ArrayBuffer) or Blob or USVString) can't be an ArrayBuffer or an ArrayBufferView larger than 2 GB exportData store.ts:5450
```
我用Agent修复了一下, 不是手写的, 代码质量可能不太好, 
1. 我本机测试了,  现在4G大体积压缩包可以成功分成两个导出, 并且成功导入回去, 缺点就是导出包的名字加了part_01后缀
2. 还有导出失败的showToast() 没有正常显示到页面上, ,新增了 .trim(), 现在可以导出失败的错误信息正常显示到前端页面, 并且打印到控制台
