### PR TITLE
Add Atlas Cloud image provider preset

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -4,6 +4,7 @@ import { normalizeBaseUrl } from '../lib/api'
 import { isApiProxyAvailable, isApiProxyLocked, readClientDevProxyConfig } from '../lib/devProxy'
 import { useStore, exportData, importData, clearData, type SettingsTab } from '../store'
 import {
+  createAtlasCloudProviderDefinition,
   createDefaultOpenAIProfile,
   DEFAULT_FAL_BASE_URL,
   DEFAULT_FAL_MODEL,
@@ -1162,6 +1163,13 @@ export default function SettingsModal() {
     }
   }
 
+  const fillAtlasCloudProviderPreset = () => {
+    setCustomProviderForm({
+      json: JSON.stringify(createAtlasCloudProviderDefinition(), null, 2),
+    })
+    setCustomProviderImportError(null)
+  }
+
   return (
         <div data-no-drag-select className="fixed inset-0 z-[70] flex items-center justify-center p-4">
       <div
@@ -2090,20 +2098,30 @@ export default function SettingsModal() {
                       disabled={isImportingJson}
                       className="flex items-center gap-1.5 rounded-xl bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-sm border border-gray-200/80 transition hover:bg-gray-50 hover:text-gray-900 disabled:opacity-50 disabled:cursor-not-allowed dark:bg-white/[0.05] dark:border-white/[0.08] dark:text-gray-300 dark:hover:bg-white/[0.08] dark:hover:text-white"
                     >
-                    {isImportingJson ? (
-                      <>
-                        <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
-                          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
-                          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
-                        </svg>
-                        导入中...
-                      </>
-                    ) : (
-                      '从剪贴板粘贴并导入'
+                      {isImportingJson ? (
+                        <>
+                          <svg className="w-3.5 h-3.5 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                          </svg>
+                          导入中...
+                        </>
+                      ) : (
+                        '从剪贴板粘贴并导入'
+                      )}
+                    </button>
+                    {!editingCustomProviderId && (
+                      <button
+                        type="button"
+                        onClick={fillAtlasCloudProviderPreset}
+                        className="flex items-center gap-1.5 rounded-xl bg-white px-3 py-2 text-xs font-medium text-gray-700 shadow-sm border border-gray-200/80 transition hover:bg-gray-50 hover:text-gray-900 dark:bg-white/[0.05] dark:border-white/[0.08] dark:text-gray-300 dark:hover:bg-white/[0.08] dark:hover:text-white"
+                      >
+                        <PlusIcon className="h-3.5 w-3.5" />
+                        填入 Atlas Cloud 预设
+                      </button>
                     )}
-                  </button>
+                  </div>
                 </div>
-              </div>
 
               <div className="flex-1 flex flex-col min-h-0">
                 <label className="flex-1 flex flex-col min-h-0">

--- a/src/lib/apiProfiles.test.ts
+++ b/src/lib/apiProfiles.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  ATLAS_CLOUD_BASE_URL,
+  ATLAS_CLOUD_EDIT_MODEL,
+  ATLAS_CLOUD_IMAGE_MODEL,
+  ATLAS_CLOUD_PROVIDER_ID,
   DEFAULT_FAL_BASE_URL,
   DEFAULT_FAL_MODEL,
   DEFAULT_IMAGES_MODEL,
   DEFAULT_OPENAI_PROFILE_ID,
   DEFAULT_SETTINGS,
+  createAtlasCloudProviderDefinition,
   createDefaultOpenAIProfile,
   createDefaultFalProfile,
   getActiveApiProfile,
@@ -591,6 +596,65 @@ describe('custom providers', () => {
     expect(profile.provider).toBe(provider.id)
     expect(profile.baseUrl).toBe(DEFAULT_SETTINGS.baseUrl)
     expect(profile.model).toBe(DEFAULT_IMAGES_MODEL)
+  })
+
+  it('provides an Atlas Cloud custom provider preset', () => {
+    const provider = createAtlasCloudProviderDefinition()
+
+    expect(provider).toMatchObject({
+      id: ATLAS_CLOUD_PROVIDER_ID,
+      name: 'Atlas Cloud',
+      submit: {
+        path: 'model/generateImage',
+        contentType: 'json',
+        taskIdPath: 'id',
+        body: {
+          model: '$profile.model',
+          prompt: '$prompt',
+          size: '$params.size',
+          quality: '$params.quality',
+          output_format: '$params.output_format',
+          moderation: '$params.moderation',
+          enable_base64_output: false,
+          enable_sync_mode: false,
+        },
+      },
+      editSubmit: {
+        path: 'model/generateImage',
+        contentType: 'json',
+        taskIdPath: 'id',
+        body: {
+          model: ATLAS_CLOUD_EDIT_MODEL,
+          prompt: '$prompt',
+          images: '$inputImages.dataUrls',
+          output_format: '$params.output_format',
+        },
+      },
+      poll: {
+        path: 'model/result/{task_id}',
+        statusPath: 'status',
+        successValues: ['completed'],
+        failureValues: ['failed'],
+        result: {
+          imageUrlPaths: ['outputs.*'],
+          b64JsonPaths: [],
+        },
+      },
+    })
+  })
+
+  it('uses Atlas Cloud URL and model when switching to the preset provider', () => {
+    const provider = createAtlasCloudProviderDefinition()
+    const profile = switchApiProfileProvider(createDefaultFalProfile(), provider.id, provider)
+
+    expect(profile).toMatchObject({
+      provider: ATLAS_CLOUD_PROVIDER_ID,
+      baseUrl: ATLAS_CLOUD_BASE_URL,
+      model: ATLAS_CLOUD_IMAGE_MODEL,
+      apiMode: 'images',
+      apiProxy: false,
+      streamImages: false,
+    })
   })
 
   it('uses API-mode specific streaming defaults and preserves partial image count', () => {

--- a/src/lib/apiProfiles.ts
+++ b/src/lib/apiProfiles.ts
@@ -33,6 +33,12 @@ export const DEFAULT_IMAGES_MODEL = 'gpt-image-2'
 export const DEFAULT_RESPONSES_MODEL = 'gpt-5.5'
 export const DEFAULT_FAL_BASE_URL = 'https://fal.run'
 export const DEFAULT_FAL_MODEL = 'openai/gpt-image-2'
+export const ATLAS_CLOUD_PROVIDER_ID = 'custom-atlascloud'
+export const ATLAS_CLOUD_BASE_URL = 'https://api.atlascloud.ai/api/v1'
+export const ATLAS_CLOUD_IMAGE_MODEL = 'openai/gpt-image-2/text-to-image'
+export const ATLAS_CLOUD_EDIT_MODEL = 'openai/gpt-image-2/edit'
+export const ATLAS_CLOUD_DEFAULT_IMAGE_SIZE = '1024x1024'
+export const ATLAS_CLOUD_DEFAULT_QUALITY = 'medium'
 export const DEFAULT_OPENAI_PROFILE_ID = 'default-openai'
 export const DEFAULT_API_TIMEOUT = 600
 
@@ -315,6 +321,72 @@ export function normalizeCustomProviderDefinitions(input: unknown): CustomProvid
     .filter((item): item is CustomProviderDefinition => Boolean(item))
 }
 
+export function createAtlasCloudProviderDefinition(): CustomProviderDefinition {
+  const result: CustomProviderResultMapping = {
+    imageUrlPaths: ['outputs.*'],
+    b64JsonPaths: [],
+  }
+
+  return {
+    id: ATLAS_CLOUD_PROVIDER_ID,
+    name: 'Atlas Cloud',
+    template: 'http-image',
+    submit: {
+      path: 'model/generateImage',
+      method: 'POST',
+      contentType: 'json',
+      body: {
+        model: '$profile.model',
+        prompt: '$prompt',
+        size: '$params.size',
+        quality: '$params.quality',
+        output_format: '$params.output_format',
+        moderation: '$params.moderation',
+        enable_base64_output: false,
+        enable_sync_mode: false,
+      },
+      taskIdPath: 'id',
+      result,
+    },
+    editSubmit: {
+      path: 'model/generateImage',
+      method: 'POST',
+      contentType: 'json',
+      body: {
+        model: ATLAS_CLOUD_EDIT_MODEL,
+        prompt: '$prompt',
+        images: '$inputImages.dataUrls',
+        size: '$params.size',
+        quality: '$params.quality',
+        output_format: '$params.output_format',
+        moderation: '$params.moderation',
+        enable_base64_output: false,
+        enable_sync_mode: false,
+      },
+      taskIdPath: 'id',
+      result,
+    },
+    poll: {
+      path: 'model/result/{task_id}',
+      method: 'GET',
+      intervalSeconds: 5,
+      statusPath: 'status',
+      successValues: ['completed'],
+      failureValues: ['failed'],
+      errorPath: 'error',
+      result,
+    },
+  }
+}
+
+function getCustomProviderProfileDefaults(customProvider: CustomProviderDefinition) {
+  if (customProvider.id !== ATLAS_CLOUD_PROVIDER_ID) return null
+  return {
+    baseUrl: ATLAS_CLOUD_BASE_URL,
+    model: ATLAS_CLOUD_IMAGE_MODEL,
+  }
+}
+
 export function createDefaultOpenAIProfile(overrides: Partial<ApiProfile> = {}): ApiProfile {
   const apiMode = overrides.apiMode ?? DEFAULT_API_URL_PATCH?.apiMode ?? 'images'
   const streamImages = overrides.streamImages ?? DEFAULT_API_URL_PATCH?.streamImages ?? getDefaultStreamImages('openai', apiMode)
@@ -388,11 +460,12 @@ export function switchApiProfileProvider(profile: ApiProfile, provider: ApiProvi
 
   if (customProvider) {
     const shouldUseOpenAIDefaults = profile.provider === 'fal'
+    const customProviderDefaults = getCustomProviderProfileDefaults(customProvider)
     return {
       ...profile,
       provider: customProvider.id,
-      baseUrl: savedDraft?.baseUrl ?? (shouldUseOpenAIDefaults ? DEFAULT_BASE_URL : profile.baseUrl || DEFAULT_BASE_URL),
-      model: savedDraft?.model ?? (shouldUseOpenAIDefaults ? DEFAULT_IMAGES_MODEL : profile.model || DEFAULT_IMAGES_MODEL),
+      baseUrl: savedDraft?.baseUrl ?? customProviderDefaults?.baseUrl ?? (shouldUseOpenAIDefaults ? DEFAULT_BASE_URL : profile.baseUrl || DEFAULT_BASE_URL),
+      model: savedDraft?.model ?? customProviderDefaults?.model ?? (shouldUseOpenAIDefaults ? DEFAULT_IMAGES_MODEL : profile.model || DEFAULT_IMAGES_MODEL),
       apiMode: 'images',
       codexCli: false,
       apiProxy: false,

--- a/src/lib/paramCompatibility.test.ts
+++ b/src/lib/paramCompatibility.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, it } from 'vitest'
 import { DEFAULT_PARAMS } from '../types'
-import { createDefaultFalProfile, createDefaultOpenAIProfile, DEFAULT_SETTINGS, normalizeSettings } from './apiProfiles'
+import {
+  ATLAS_CLOUD_BASE_URL,
+  ATLAS_CLOUD_DEFAULT_IMAGE_SIZE,
+  ATLAS_CLOUD_DEFAULT_QUALITY,
+  ATLAS_CLOUD_IMAGE_MODEL,
+  ATLAS_CLOUD_PROVIDER_ID,
+  createDefaultFalProfile,
+  createDefaultOpenAIProfile,
+  DEFAULT_SETTINGS,
+  normalizeSettings,
+} from './apiProfiles'
 import { getOutputImageLimitForSettings, normalizeParamsForSettings } from './paramCompatibility'
 
 describe('parameter compatibility', () => {
@@ -49,5 +59,39 @@ describe('parameter compatibility', () => {
 
     expect(normalizeParamsForSettings({ ...DEFAULT_PARAMS, size: 'auto' }, settings).size).toBe('1360x1024')
     expect(normalizeParamsForSettings({ ...DEFAULT_PARAMS, size: 'auto' }, settings, { hasInputImages: true }).size).toBe('auto')
+  })
+
+  it('normalizes Atlas Cloud params to the supported image schema', () => {
+    const atlasCloudProfile = createDefaultOpenAIProfile({
+      id: 'atlascloud-profile',
+      provider: ATLAS_CLOUD_PROVIDER_ID,
+      baseUrl: ATLAS_CLOUD_BASE_URL,
+      apiKey: 'atlas-key',
+      model: ATLAS_CLOUD_IMAGE_MODEL,
+    })
+    const settings = normalizeSettings({
+      ...DEFAULT_SETTINGS,
+      customProviders: [{ id: ATLAS_CLOUD_PROVIDER_ID, name: 'Atlas Cloud', submit: { path: 'model/generateImage' } }],
+      profiles: [atlasCloudProfile],
+      activeProfileId: atlasCloudProfile.id,
+    })
+
+    expect(getOutputImageLimitForSettings(settings)).toBe(1)
+    expect(normalizeParamsForSettings({
+      ...DEFAULT_PARAMS,
+      n: 3,
+      size: 'auto',
+      quality: 'auto',
+      output_format: 'webp',
+      moderation: 'auto',
+      output_compression: 80,
+    }, settings)).toMatchObject({
+      n: 1,
+      size: ATLAS_CLOUD_DEFAULT_IMAGE_SIZE,
+      quality: ATLAS_CLOUD_DEFAULT_QUALITY,
+      output_format: 'png',
+      moderation: 'low',
+      output_compression: null,
+    })
   })
 })

--- a/src/lib/paramCompatibility.ts
+++ b/src/lib/paramCompatibility.ts
@@ -1,13 +1,16 @@
 import { DEFAULT_PARAMS, type AppSettings, type TaskParams } from '../types'
-import { getActiveApiProfile } from './apiProfiles'
+import { ATLAS_CLOUD_DEFAULT_IMAGE_SIZE, ATLAS_CLOUD_DEFAULT_QUALITY, ATLAS_CLOUD_PROVIDER_ID, getActiveApiProfile } from './apiProfiles'
 import { normalizeImageSize } from './size'
 
+export const MAX_ATLAS_CLOUD_OUTPUT_IMAGES = 1
 export const DEFAULT_FAL_IMAGE_SIZE = '1360x1024'
 export const MAX_FAL_OUTPUT_IMAGES = 4
 export const MAX_OPENAI_OUTPUT_IMAGES = 10
 
 export function getOutputImageLimitForSettings(settings: AppSettings) {
-  return getActiveApiProfile(settings).provider === 'fal' ? MAX_FAL_OUTPUT_IMAGES : MAX_OPENAI_OUTPUT_IMAGES
+  const provider = getActiveApiProfile(settings).provider
+  if (provider === ATLAS_CLOUD_PROVIDER_ID) return MAX_ATLAS_CLOUD_OUTPUT_IMAGES
+  return provider === 'fal' ? MAX_FAL_OUTPUT_IMAGES : MAX_OPENAI_OUTPUT_IMAGES
 }
 
 export function normalizeParamsForSettings(
@@ -31,6 +34,14 @@ export function normalizeParamsForSettings(
     if (!options.hasInputImages && nextParams.size === 'auto') nextParams.size = DEFAULT_FAL_IMAGE_SIZE
     if (nextParams.quality === 'auto') nextParams.quality = 'high'
     nextParams.moderation = DEFAULT_PARAMS.moderation
+    nextParams.output_compression = DEFAULT_PARAMS.output_compression
+  }
+
+  if (activeProfile.provider === ATLAS_CLOUD_PROVIDER_ID) {
+    if (nextParams.size === 'auto') nextParams.size = ATLAS_CLOUD_DEFAULT_IMAGE_SIZE
+    if (nextParams.quality === 'auto') nextParams.quality = ATLAS_CLOUD_DEFAULT_QUALITY
+    if (nextParams.output_format === 'webp') nextParams.output_format = DEFAULT_PARAMS.output_format
+    if (nextParams.moderation === 'auto') nextParams.moderation = 'low'
     nextParams.output_compression = DEFAULT_PARAMS.output_compression
   }
 


### PR DESCRIPTION
## Summary
- add an Atlas Cloud custom image provider preset using the existing HTTP provider manifest flow
- default the preset to Atlas Cloud Media API and GPT Image 2 text-to-image/edit models
- normalize Atlas Cloud image params to supported defaults before requests

## Tests
- npm test -- src/lib/apiProfiles.test.ts src/lib/paramCompatibility.test.ts
- npm test
- npm run build