### PR TITLE
fix: allow editing API base URL when API proxy is enabled

### DIFF
--- a/src/components/SettingsModal.tsx
+++ b/src/components/SettingsModal.tsx
@@ -1392,9 +1392,9 @@ export default function SettingsModal() {
                     onChange={(e) => updateActiveProfile({ baseUrl: e.target.value })}
                     onBlur={(e) => commitActiveProfilePatch({ baseUrl: e.target.value })}
                     type="text"
-                    disabled={apiProxyEnabled}
+                    disabled={defaultConfigOnly}
                     placeholder={activeProfile.provider === 'fal' ? DEFAULT_FAL_BASE_URL : DEFAULT_SETTINGS.baseUrl}
-                    className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${apiProxyEnabled ? 'opacity-50 cursor-not-allowed' : ''}`}
+                    className={`w-full rounded-xl border border-gray-200/70 bg-white/60 px-3 py-2.5 text-sm text-gray-700 outline-none transition focus:border-blue-300 dark:border-white/[0.08] dark:bg-white/[0.03] dark:text-gray-200 dark:focus:border-blue-500/50 ${defaultConfigOnly ? 'opacity-50 cursor-not-allowed' : ''}`}
                   />
                   <div data-selectable-text className="mt-1.5 min-h-[22px] flex items-center text-xs text-gray-500 dark:text-gray-500">
                     {apiProxyEnabled ? (


### PR DESCRIPTION
## Problem

When the API proxy is enabled (ENABLE_API_PROXY=true), the API base URL input in Settings is disabled because it uses `disabled={apiProxyEnabled}`.

This wrongly locks the URL field in a common setup: **proxy enabled + user-provided custom endpoint**. The proxy setting only means requests go through a server-side relay — it should not prevent the user from entering their own base URL.

## Fix

Change the disabled condition from `apiProxyEnabled` to `defaultConfigOnly` — the URL should only be locked when the deployment explicitly locks the default configuration (SHOW_DEFAULT_CONFIG_ONLY=true).

## Files changed

- `src/components/SettingsModal.tsx`: 2 lines (disabled condition + opacity class)

## Verification

- `npm run build` passes
- `npm test`: 400 tests pass, no regression
- Manual: with ENABLE_API_PROXY=true, the base URL field is now editable and the proxy still routes requests through /api-proxy/