### PR TITLE
fix: ignore Enter keydown during IME composition

### DIFF
--- a/src/components/InputBar.tsx
+++ b/src/components/InputBar.tsx
@@ -343,6 +343,7 @@ export default function InputBar() {
   const imageDragPreviewRef = useRef<HTMLElement | null>(null)
   const suppressImageClickRef = useRef(false)
   const isUserInputRef = useRef(false)
+  const isComposingRef = useRef(false)
   const imageHintLockedRef = useRef(false)
   const imageHintReleaseRef = useRef<(() => void) | null>(null)
   const [cursorPos, setCursorPos] = useState(0)
@@ -837,6 +838,13 @@ export default function InputBar() {
   }
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // 输入法（注音/拼音等）用 Enter 确认候选字时，浏览器会派发一个 key 为 Enter 的
+    // keydown 事件；若不忽略它，会与输入法自身的候选字提交动作重叠，导致文字被
+    // 重复插入或误触发提交/换行。
+    if (e.key === 'Enter' && (e.nativeEvent.isComposing || isComposingRef.current || e.nativeEvent.keyCode === 229)) {
+      return
+    }
+
     if (showAtImageMenu) {
       if (e.key === 'ArrowDown') {
         e.preventDefault()
@@ -1680,6 +1688,12 @@ export default function InputBar() {
                 setAtImageMenuDismissed(false)
               }}
               onKeyDown={handleKeyDown}
+              onCompositionStart={() => {
+                isComposingRef.current = true
+              }}
+              onCompositionEnd={() => {
+                isComposingRef.current = false
+              }}
               onPaste={handlePromptPaste}
               onCopy={handlePromptCopy}
               onClick={(e) => {


### PR DESCRIPTION
## 問題
首頁輸入框用注音（或其他 IME）打字，打完候選字按 Enter 確認時，
文字會被多插入一次。

## 原因
IME 用 Enter 確認候選字時，瀏覽器仍會派發一個 key 為 "Enter" 的
keydown 事件給頁面。輸入框的 keydown handler 沒有判斷組字狀態，
把這個事件當成一般 Enter 處理，額外執行了換行／提交邏輯，跟 IME
自己提交候選字的動作疊加，導致文字重複。

## 修正
在 handleKeyDown 一開始檢查是否正在組字中
（`e.nativeEvent.isComposing` / 自行追蹤的 composing ref /
`keyCode === 229`），是的話直接 return，交給 IME 自己完成提交，
不再執行自訂的換行／提交邏輯。

## 測試
- `npx tsc -b --noEmit` 通過
- `npx vitest run` 512 個測試全部通過
- 手動模擬 compositionstart → insertText → keydown(Enter,
  isComposing=true) → compositionend，確認 `defaultPrevented`
  為 false 且文字不重複；一般（非組字）Enter 行為不變